### PR TITLE
[#50] feat(rating): rating component 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-use-controllable-state": "^1.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state':
+        specifier: ^1.2.2
+        version: 1.2.2(@types/react@19.2.7)(react@19.2.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1

--- a/src/shared/ui/rating/rating.tsx
+++ b/src/shared/ui/rating/rating.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import type { KeyboardEvent, MouseEvent, ReactElement, ReactNode } from "react";
+import {
+  Children,
+  cloneElement,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+} from "react";
+
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { type LucideProps, StarIcon } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils/utils";
+
+interface RatingContextValue {
+  value: number;
+  readOnly: boolean;
+  hoverValue: number | null;
+  focusedStar: number | null;
+  handleValueChange: (
+    event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
+    value: number
+  ) => void;
+  handleKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+  setHoverValue: (value: number | null) => void;
+  setFocusedStar: (value: number | null) => void;
+}
+
+const RatingContext = createContext<RatingContextValue | null>(null);
+
+const useRating = () => {
+  const context = useContext(RatingContext);
+  if (!context) {
+    throw new Error("useRating must be used within a Rating component");
+  }
+  return context;
+};
+
+export type RatingButtonProps = LucideProps & {
+  index?: number;
+  icon?: ReactElement<LucideProps>;
+};
+
+export function RatingButton({
+  index: providedIndex,
+  size = 20,
+  className,
+  icon = <StarIcon />,
+}: RatingButtonProps) {
+  const {
+    value,
+    readOnly,
+    hoverValue,
+    focusedStar,
+    handleValueChange,
+    handleKeyDown,
+    setHoverValue,
+    setFocusedStar,
+  } = useRating();
+
+  const index = providedIndex ?? 0;
+  const isActive = index < (hoverValue ?? focusedStar ?? value ?? 0);
+  let tabIndex = -1;
+
+  if (!readOnly) {
+    tabIndex = value === index + 1 ? 0 : -1;
+  }
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      handleValueChange(event, index + 1);
+    },
+    [handleValueChange, index]
+  );
+
+  const handleMouseEnter = useCallback(() => {
+    if (!readOnly) {
+      setHoverValue(index + 1);
+    }
+  }, [readOnly, setHoverValue, index]);
+
+  const handleFocus = useCallback(() => {
+    setFocusedStar(index + 1);
+  }, [setFocusedStar, index]);
+
+  const handleBlur = useCallback(() => {
+    setFocusedStar(null);
+  }, [setFocusedStar]);
+
+  return (
+    <button
+      className={cn(
+        "focus-visible:ring-ring rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        "p-0.5",
+        readOnly && "cursor-default",
+        className
+      )}
+      disabled={readOnly}
+      onBlur={handleBlur}
+      onClick={handleClick}
+      onFocus={handleFocus}
+      onKeyDown={handleKeyDown}
+      onMouseEnter={handleMouseEnter}
+      tabIndex={tabIndex}
+      type="button"
+    >
+      {cloneElement(icon, {
+        size,
+        className: cn(
+          "transition-colors duration-200",
+          isActive && "fill-current",
+          !readOnly && "cursor-pointer"
+        ),
+        "aria-hidden": "true",
+      })}
+    </button>
+  );
+}
+
+export interface RatingProps {
+  defaultValue?: number;
+  value?: number;
+  onChange?: (
+    event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
+    value: number
+  ) => void;
+  onValueChange?: (value: number) => void;
+  readOnly?: boolean;
+  className?: string;
+  children?: ReactNode;
+}
+
+export function Rating({
+  value: controlledValue,
+  onValueChange: controlledOnValueChange,
+  defaultValue = 0,
+  onChange,
+  readOnly = false,
+  className,
+  children,
+  ...props
+}: RatingProps) {
+  const [hoverValue, setHoverValue] = useState<number | null>(null);
+  const [focusedStar, setFocusedStar] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [value, onValueChange] = useControllableState({
+    defaultProp: defaultValue,
+    prop: controlledValue,
+    onChange: controlledOnValueChange,
+  });
+
+  const handleValueChange = useCallback(
+    (event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>, newValue: number) => {
+      if (!readOnly) {
+        onChange?.(event, newValue);
+        onValueChange?.(newValue);
+      }
+    },
+    [readOnly, onChange, onValueChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (readOnly) {
+        return;
+      }
+
+      const total = Children.count(children);
+      let newValue = focusedStar !== null ? focusedStar : (value ?? 0);
+
+      switch (event.key) {
+        case "ArrowRight":
+          if (event.shiftKey || event.metaKey) {
+            newValue = total;
+          } else {
+            newValue = Math.min(total, newValue + 1);
+          }
+          break;
+        case "ArrowLeft":
+          if (event.shiftKey || event.metaKey) {
+            newValue = 1;
+          } else {
+            newValue = Math.max(1, newValue - 1);
+          }
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      setFocusedStar(newValue);
+      handleValueChange(event, newValue);
+    },
+    [focusedStar, value, children, readOnly, handleValueChange]
+  );
+
+  useEffect(() => {
+    if (focusedStar !== null && containerRef.current) {
+      const buttons = containerRef.current.querySelectorAll("button");
+      buttons[focusedStar - 1]?.focus();
+    }
+  }, [focusedStar]);
+
+  const contextValue: RatingContextValue = useMemo(
+    () => ({
+      value: value ?? 0,
+      readOnly,
+      hoverValue,
+      focusedStar,
+      handleValueChange,
+      handleKeyDown,
+      setHoverValue,
+      setFocusedStar,
+    }),
+    [
+      value,
+      readOnly,
+      hoverValue,
+      focusedStar,
+      handleValueChange,
+      handleKeyDown,
+      setHoverValue,
+      setFocusedStar,
+    ]
+  );
+  return (
+    <RatingContext.Provider value={contextValue}>
+      <div
+        aria-label="Rating"
+        className={cn("inline-flex items-center gap-0.5", className)}
+        onMouseLeave={() => setHoverValue(null)}
+        ref={containerRef}
+        role="radiogroup"
+        tabIndex={-1}
+        {...props}
+      >
+        {Children.map(children, (child, index) => {
+          if (!child) {
+            return null;
+          }
+
+          return cloneElement(child as ReactElement<RatingButtonProps>, {
+            index,
+          });
+        })}
+      </div>
+    </RatingContext.Provider>
+  );
+}


### PR DESCRIPTION
## 📖 개요

shadcn기반 rating 컴포넌트를 추가
++ 프로젝트 컨벤션에 맞도록 파일 위치 및 export 방식 정리

## 📌 관련 이슈
- Close #50  

## 🛠️ 상세 작업 내용

	•	rating 컴포넌트 추가
	•	컴포넌트 파일을 적절한 디렉토리로 이동
	•	프로젝트 export 컨벤션에 맞도록 default export → named export로 변경


## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트
