### PR TITLE
feat(color): add brand color variables to theme and dark mode

### DIFF
--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -7,8 +7,8 @@
   /* Color System */
   --color-brand: oklch(0.4758 0.2241 288.5);
   --color-brand-contrast: var(--color-zinc-50);
-  --color-brand-surface: #0000ff0e;
-  --color-brand-text: #3000bebb;
+  --color-brand-surface: oklch(0.452 0.313214 264.052 / 5.49%);
+  --color-brand-text: oklch(0.3817 0.240152 274.8706 / 73.33%);
 
   /* Typography System */
   --text-xs--letter-spacing: -0.015rem; /* x-small */
@@ -100,8 +100,8 @@
 }
 
 .dark {
-  --color-brand-surface: #6541fd40;
-  --color-brand-text: #b4a6ff;
+  --color-brand-surface: oklch(0.5426 0.2587 282.27 / 25.1%);
+  --color-brand-text: oklch(0.7711 0.1259 290.34);
 
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## 📖 개요

라이트/다크모드 호환되는 브랜드 컬러 관련 변수 추가

## 📌 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- contrast, surface, text 관련 CSS 변수 생성
- 다크 모드용 surface, text 추가

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷

<img width="125" height="129" alt="스크린샷 2025-12-12 10 25 13" src="https://github.com/user-attachments/assets/8bdba50b-c5bf-401f-8900-a4bef3c719ae" />

<img width="123" height="126" alt="스크린샷 2025-12-12 10 25 18" src="https://github.com/user-attachments/assets/23b05202-f2d2-46fb-8d3f-c3200fcb1a6f" />

## ⚠️ 주의 사항

색상 추가로 구현된 컴포넌트들 점검 부탁드립니다.

## 👥 리뷰 확인 사항

**`contrast`**: 브랜드 컬러를 배경으로 깔았을 때 대비용 색상 (zinc-50)
**`surface`**: 브랜드 컬러를 기반 연한 배경 색상
**`text`**: 브랜드 컬러 기반 가독성을 위한 텍스트 색상
