### PR TITLE
[#57] feat(button): accent variant 추가 및 일부 스타일 변경

### DIFF
--- a/src/shared/ui/button/button.tsx
+++ b/src/shared/ui/button/button.tsx
@@ -10,12 +10,13 @@ export const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-brand text-brand-foreground hover:bg-brand/90",
+        primary: "bg-brand text-brand-contrast hover:bg-brand/90",
+        accent: "bg-brand-surface text-brand-text",
         outline:
           "bg-background hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 border shadow-xs",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary hover:text-brand",
+        link: "text-primary hover:text-brand-text",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -27,16 +28,16 @@ export const buttonVariants = cva(
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "primary",
       size: "default",
     },
   }
 );
 
-type ButtonProps = ComponentPropsWithoutRef<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  };
+interface ButtonProps
+  extends ComponentPropsWithoutRef<"button">, VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
 
 export default function Button({
   className,


### PR DESCRIPTION
## 📖 개요

accent variant 추가 및 일부 스타일 변경

## 📌 관련 이슈

- Close #57 

## 🛠️ 상세 작업 내용

- default variant를 `primary`로 교체
- primary text 컬러를 `contrast`로 교체
- 새로운 `accent` variant 추가
- `link` variant 스타일 개선
- ButtonProps를 interface 기반으로 재정리하여 가독성 향상

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷

<img width="520" height="44" alt="스크린샷 2025-12-12 13 19 25" src="https://github.com/user-attachments/assets/6cf3eb31-3a21-4d02-b5b0-df8d15a66c1c" />

## ⚠️ 주의 사항

default variant 이름을 primary로 교체했는데, 사용하신 부분이 있다면 확인 부탁드립니다

## 👥 리뷰 확인 사항

_N/A_
