### PR TITLE
[#94] feat(header): SubHeader 컴포넌트 추가

### DIFF
--- a/src/widgets/sub-header/sub-header.tsx
+++ b/src/widgets/sub-header/sub-header.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { ComponentProps, ReactNode } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { ChevronLeft } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils/utils";
+import Button from "@/shared/ui/button/button";
+
+export interface SubHeaderProps extends Omit<ComponentProps<"header">, "children" | "content"> {
+  content?: ReactNode;
+}
+
+export function SubHeader({ content = "", className, ...props }: SubHeaderProps) {
+  const router = useRouter();
+
+  return (
+    <header className={cn("w-full md:hidden", className)} {...props}>
+      <div className="flex h-14 items-center gap-3 px-2.5">
+        <Button variant="ghost" size="icon-lg" aria-label="뒤로가기" onClick={() => router.back()}>
+          <ChevronLeft />
+        </Button>
+
+        <div className="flex flex-1 items-center">
+          {typeof content === "string" ? (
+            <h1 className="truncate font-semibold">{content}</h1>
+          ) : (
+            content
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## 📖 개요

SubHeader 컴포넌트 추가

## 📌 관련 이슈

- Close #94 

## 🛠️ 상세 작업 내용

- 뒤로가기 버튼을 포함한 SubHeader React 컴포넌트 신규 구현
- Next.js 라우터를 활용한 네비게이션 처리

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷

<img width="121" height="57" alt="스크린샷 2025-12-15 17 16 54" src="https://github.com/user-attachments/assets/67b11af8-230b-41c4-8c33-18573c96f15b" />

<img width="172" height="64" alt="스크린샷 2025-12-15 17 16 29" src="https://github.com/user-attachments/assets/1b9902e1-f97e-4bb2-ad78-60f3cfc2c4f0" />

## 👥 리뷰 확인 사항

추후 `SearchInput`, DM에서는 `Avatar` 등이 들어갈 수 있기 때문에 `content`는 `ReactNode` 타입으로 설정했습니다.
뒤로가기 버튼은 `ghost` 형태로 호버 시 배경이 뜨는 스타일로 설정했습니다.