### PR TITLE
[#33] feat(header): Header 컴포넌트 추가 및 레이아웃에 통합

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "next-themes";
 import "@/shared/styles/globals.css";
 import { ToastRegistry } from "@/shared/ui/toast/toast-registry";
 import { BottomNav } from "@/widgets/bottom-nav";
+import { Header } from "@/widgets/header/header";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -32,6 +33,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <Header />
           {children}
           <ToastRegistry />
           <BottomNav />

--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -1,0 +1,60 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { Bell, Plus, User } from "lucide-react";
+
+import Logo from "@/shared/assets/icons/windfall.svg";
+import Button from "@/shared/ui/button/button";
+import SearchInput from "@/shared/ui/input/search-input";
+
+// TODO: BottomNav와 model 공유할 수 있도록 refactor
+export function Header() {
+  return (
+    <header className="bg-background sticky top-0 z-50 hidden h-14 select-none md:flex">
+      <div className="mx-auto flex h-full w-full max-w-7xl items-center justify-between gap-4 px-4">
+        <Link href="/" className="shrink-0">
+          <h1 className="flex items-center gap-2">
+            <Image src={Logo} alt="윈드폴 로고" />
+            <span className="hidden text-xl font-medium lg:block">Windfall</span>
+          </h1>
+        </Link>
+
+        <form className="flex min-w-0 flex-1">
+          <div className="mx-auto w-full max-w-[626px]">
+            <label htmlFor="search" className="sr-only">
+              검색
+            </label>
+            {/* TODO: SearchInput 스타일 리팩토링 */}
+            <SearchInput id="search" />
+          </div>
+        </form>
+
+        {/* TODO: 로그인 아닐 시 로그인 버튼 */}
+        <div className="flex shrink-0 items-center gap-3">
+          <Button asChild aria-label="경매 등록" size="icon-lg" className="lg:hidden">
+            <Link href="/auctions/new">
+              <Plus className="size-5" />
+            </Link>
+          </Button>
+
+          <Button asChild aria-label="경매 등록" size="lg" className="hidden lg:flex">
+            <Link href="/auctions/new">
+              <Plus className="size-5" />
+              <span>경매 등록</span>
+            </Link>
+          </Button>
+
+          <Button aria-label="알림" size="icon-lg" variant="ghost" className="relative">
+            <Bell className="size-5" />
+            <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-500" />
+          </Button>
+
+          {/* TODO: 로그인 연결 후 유저 아바타 */}
+          <Button aria-label="프로필" size="icon-lg" variant="ghost">
+            <User className="size-5" />
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## 📖 개요

Header 컴포넌트 추가 및 레이아웃에 통합

## 📌 관련 이슈

- Close #33 

## 🛠️ 상세 작업 내용

- src/widgets/header에 Header 컴포넌트 신규 구현
- 네비게이션, 검색 입력, 사용자 액션 버튼 포함
- RootLayout에 Header를 추가

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷

### md

<img width="789" height="79" alt="스크린샷 2025-12-16 05 21 33" src="https://github.com/user-attachments/assets/d87d452b-063e-4e89-b216-0ee3a6f53fa2" />

### lg Dark

<img width="1038" height="70" alt="스크린샷 2025-12-16 05 21 47" src="https://github.com/user-attachments/assets/71542506-b6a0-4dee-8c0b-75845eb84249" />

### xl

<img width="1308" height="90" alt="스크린샷 2025-12-16 05 21 56" src="https://github.com/user-attachments/assets/0fffead0-7312-4cdb-9ee7-28e19d46e7da" />

## 👥 리뷰 확인 사항

BottomNav와 공유할 수 있는 것들은 공통으로 빼야 하는데 일단 퍼블리싱 우선 하려고 TODO로 적어놨습니다 🥹
기능 붙일 때 공통으로 entities에서 작업하도록 하겠습니다.