### PR TITLE
fix(api): server API fetch에서 cookie 처리 제거

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,7 @@ const nextConfig: NextConfig = {
         protocol: "http",
         hostname: "k.kakaocdn.net",
       },
+      { protocol: "https", hostname: "picsum.photos" },
     ],
   },
   async rewrites() {

--- a/src/shared/api/server.ts
+++ b/src/shared/api/server.ts
@@ -1,5 +1,3 @@
-import { cookies } from "next/headers";
-
 import type { ApiResponseType } from "@/shared/api/types/response";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -12,12 +10,6 @@ export async function fetch<TResponse, TRequest = unknown>(
   path: string,
   init?: StrictRequestInit<TRequest>
 ): Promise<ApiResponseType<TResponse>> {
-  const cookieStore = await cookies();
-  const cookieHeader = cookieStore
-    .getAll()
-    .map((cookie) => `${cookie.name}=${cookie.value}`)
-    .join("; ");
-
   const url = new URL(path, API_URL);
 
   const hasBody = init?.body !== undefined;
@@ -26,7 +18,6 @@ export async function fetch<TResponse, TRequest = unknown>(
     ...init,
 
     headers: {
-      Cookie: cookieHeader,
       ...(hasBody ? { "Content-Type": "application/json" } : {}),
       ...(init?.headers ?? {}),
     },


### PR DESCRIPTION
## 📖 개요

server API fetch에서 cookie 처리 제거

## 📌 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- `shared/api/server.ts`에서 cookie 관련 로직 제거
- `next.config.ts`에 허용 이미지 도메인으로 `picsum.photos` 추가

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 👥 리뷰 확인 사항

next.config.ts의 경우 BE에서 넣은 시드 데이터가 picsum이기 때문에 넣었습니다.
추후 제거 예정입니다.
