### PR TITLE
[#195] fix(login): route.ts sameSite & secure 문제 해결, api에 쿠키를 전달하도록 임시 수정

### DIFF
--- a/src/app/api/auth/callback/[provider]/route.ts
+++ b/src/app/api/auth/callback/[provider]/route.ts
@@ -1,17 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 
+const isProduction = process.env.NODE_ENV === "production";
+
 const COOKIE_OPTIONS = {
   ACCESS_TOKEN: {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "none" as const,
+    secure: isProduction,
+    sameSite: isProduction ? ("none" as const) : ("lax" as const),
     path: "/",
     maxAge: 60 * 60,
   },
   REFRESH_TOKEN: {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "none" as const,
+    secure: isProduction,
+    sameSite: isProduction ? ("none" as const) : ("lax" as const),
     path: "/",
     maxAge: 60 * 60 * 24 * 7,
   },

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -3,18 +3,20 @@ import { NextRequest, NextResponse } from "next/server";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
+const isProduction = process.env.NODE_ENV === "production";
+
 const COOKIE_OPTIONS = {
   ACCESS_TOKEN: {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "none" as const,
+    secure: isProduction,
+    sameSite: isProduction ? ("none" as const) : ("lax" as const),
     path: "/",
     maxAge: 60 * 60,
   },
   REFRESH_TOKEN: {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "none" as const,
+    secure: isProduction,
+    sameSite: isProduction ? ("none" as const) : ("lax" as const),
     path: "/",
     maxAge: 60 * 60 * 24 * 7,
   },
@@ -60,16 +62,25 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
   const refreshToken = cookieStore.get("refreshToken")?.value;
 
   const headers = new Headers(req.headers);
+
+  // Authorization 헤더 설정
   if (accessToken) {
     headers.set("Authorization", `Bearer ${accessToken}`);
   }
 
-  // 불필요한 헤더 삭제, 재시도 시 문제 방지
   headers.delete("host");
-  headers.delete("cookie");
+  headers.delete("cookie"); // 기존의 모든 쿠키 삭제 (보안 및 충돌 방지)
   headers.delete("content-length");
 
-  // Body 읽기, 한 번만 읽고 재사용
+  // 백엔드 @CookieValue 지원을 위해 쿠키 헤더 수동 재구성
+  const backendCookies = [];
+  if (accessToken) backendCookies.push(`accessToken=${accessToken}`);
+  if (refreshToken) backendCookies.push(`refreshToken=${refreshToken}`);
+
+  if (backendCookies.length > 0) {
+    headers.set("Cookie", backendCookies.join("; "));
+  }
+
   const requestBody = await getRequestBody(req);
 
   try {
@@ -104,8 +115,16 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
       const newAccessToken = refreshData.data.accessToken;
       const newRefreshToken = refreshData.data.refreshToken;
 
-      // 새로운 액세스 토큰으로 재요청
+      // 새로운 액세스 토큰으로 헤더 업데이트
       headers.set("Authorization", `Bearer ${newAccessToken}`);
+
+      // 재요청 시에도 쿠키 헤더 업데이트 필요
+      const newBackendCookies = [];
+      if (newAccessToken) newBackendCookies.push(`accessToken=${newAccessToken}`);
+      if (newRefreshToken) newBackendCookies.push(`refreshToken=${newRefreshToken}`);
+      if (newBackendCookies.length > 0) {
+        headers.set("Cookie", newBackendCookies.join("; "));
+      }
 
       backendRes = await fetch(backendUrl, {
         method: req.method,
@@ -142,7 +161,6 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
   }
 }
 
-// 모든 HTTP 요청에 대응
 export {
   proxyHandler as GET,
   proxyHandler as POST,
@@ -150,3 +168,128 @@ export {
   proxyHandler as DELETE,
   proxyHandler as PATCH,
 };
+
+// user-api가 accessToken이 아닌 cookie자체를 받아서 일단 주석처리
+// async function getRequestBody(req: NextRequest): Promise<string | ArrayBuffer | null> {
+//   const contentType = req.headers.get("content-type");
+
+//   if (contentType?.includes("application/json")) {
+//     try {
+//       return JSON.stringify(await req.json());
+//     } catch {
+//       return null;
+//     }
+//   }
+
+//   // 파일 업로드 등의 경우 ArrayBuffer로 처리
+//   const arrayBuffer = await req.arrayBuffer();
+//   return arrayBuffer.byteLength > 0 ? arrayBuffer : null;
+// }
+
+// function clearAuthCookies(response: NextResponse) {
+//   response.cookies.delete("accessToken");
+//   response.cookies.delete("refreshToken");
+// }
+
+// async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+//   const { path } = await params;
+
+//   const pathString = path.join("/");
+//   const searchParams = req.nextUrl.search;
+//   const backendUrl = `${API_BASE_URL}/${pathString}${searchParams}`;
+
+//   const cookieStore = await cookies();
+//   const accessToken = cookieStore.get("accessToken")?.value;
+//   const refreshToken = cookieStore.get("refreshToken")?.value;
+
+//   const headers = new Headers(req.headers);
+//   if (accessToken) {
+//     headers.set("Authorization", `Bearer ${accessToken}`);
+//   }
+
+//   // 불필요한 헤더 삭제, 재시도 시 문제 방지
+//   headers.delete("host");
+//   headers.delete("cookie");
+//   headers.delete("content-length");
+
+//   // Body 읽기, 한 번만 읽고 재사용
+//   const requestBody = await getRequestBody(req);
+
+//   try {
+//     let backendRes = await fetch(backendUrl, {
+//       method: req.method,
+//       headers,
+//       body: requestBody,
+//       cache: "no-store",
+//     });
+
+//     if (backendRes.status === 401 && refreshToken) {
+//       const refreshRes = await fetch(`${API_BASE_URL}/api/v1/auth/refresh`, {
+//         method: "POST",
+//         headers: { "Content-Type": "application/json" },
+//         body: JSON.stringify({ refreshToken }),
+//         cache: "no-store",
+//       });
+
+//       // 토큰이 만료되었거나 문제가 있다면 삭제
+//       if (!refreshRes.ok) {
+//         console.error("Refresh token failed or expired.");
+
+//         const response = NextResponse.json(
+//           { error: "Session expired. Please login again." },
+//           { status: 401 }
+//         );
+//         clearAuthCookies(response);
+//         return response;
+//       }
+
+//       const refreshData: RefreshResponse = await refreshRes.json();
+//       const newAccessToken = refreshData.data.accessToken;
+//       const newRefreshToken = refreshData.data.refreshToken;
+
+//       // 새로운 액세스 토큰으로 재요청
+//       headers.set("Authorization", `Bearer ${newAccessToken}`);
+
+//       backendRes = await fetch(backendUrl, {
+//         method: req.method,
+//         headers,
+//         body: requestBody,
+//         cache: "no-store",
+//       });
+
+//       if (backendRes.status === 401) {
+//         console.error("Request failed even after token refresh.");
+//         const response = NextResponse.json({ error: "Authentication failed" }, { status: 401 });
+//         clearAuthCookies(response);
+//         return response;
+//       }
+
+//       const response = new NextResponse(backendRes.body, {
+//         status: backendRes.status,
+//         headers: backendRes.headers,
+//       });
+
+//       response.cookies.set("accessToken", newAccessToken, COOKIE_OPTIONS.ACCESS_TOKEN);
+//       response.cookies.set("refreshToken", newRefreshToken, COOKIE_OPTIONS.REFRESH_TOKEN);
+
+//       return response;
+//     }
+
+//     return new NextResponse(backendRes.body, {
+//       status: backendRes.status,
+//       headers: backendRes.headers,
+//     });
+//   } catch (error) {
+//     console.error("Proxy Error:", error);
+//     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+//   }
+// }
+
+// // 모든 HTTP 요청에 대응
+// export {
+//   proxyHandler as GET,
+//   proxyHandler as POST,
+//   proxyHandler as PUT,
+//   proxyHandler as DELETE,
+//   proxyHandler as PATCH,
+// };


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
route.ts를 수정해서 로컬과 배포에서 쿠키가 설정되도록 수정

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #195

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- route.ts에서 쿠키 옵션이 로컬인지 배포인지 따라서 secure 옵션 대응
- sameSite 옵션이 로컬인지 배포인지 따라서 none & lax 대응
- auth/user/basic api 호출을 위해서 백엔드에 쿠키를 보내주도록 수정

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷 (Optional)

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->

_N/A_

## ⚠️ 주의 사항 (Optional)

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->
- vercel 배포시에 env에 NODE_ENV = production을 넣어주셔야 쿠키 옵션이 대응합니다.
- refresh api는 아직 구현되지 않아서 accessToken이 만료되면 오류가 발생합니다, 1시간에 한번 씩 다시 로그인해야합니다.

_N/A_

## 👥 리뷰 확인 사항 (Optional)

<!-- 리뷰어가 집중해서 봐야 하는 부분이 있다면 작성해주세요 -->

_N/A_
