### PR TITLE
[#222] fix(chat): 목업 데이터 타입 복구

### DIFF
--- a/src/entities/chat/api/mocks.ts
+++ b/src/entities/chat/api/mocks.ts
@@ -1,4 +1,4 @@
-import type { Chat, Message } from "../model/types";
+import type { Chat, Message } from "@/features/chat";
 
 export const mockChats: Chat[] = [
   {

--- a/src/entities/chat/ui/chat-bubble.tsx
+++ b/src/entities/chat/ui/chat-bubble.tsx
@@ -1,6 +1,5 @@
+import type { Message } from "@/features/chat";
 import { cn } from "@/shared/lib/utils/utils";
-
-import type { Message } from "../model/types";
 
 interface ChatBubbleProps {
   message: Message;

--- a/src/features/chat/model/types.ts
+++ b/src/features/chat/model/types.ts
@@ -1,3 +1,29 @@
+export interface Chat {
+  id: string;
+  name: string;
+  avatar: string;
+  lastMessage: string;
+  lastMessageTime: string;
+  unreadCount: number;
+  product?: Product;
+}
+
+export interface Product {
+  id: string;
+  name: string;
+  image: string;
+  price: number;
+  purchaseDate: string;
+}
+
+export interface Message {
+  id: string;
+  message: string;
+  time: string;
+  isMine: boolean;
+  isRead: boolean;
+}
+
 export type ListFilter = "ALL" | "BUY" | "SELL";
 
 export interface ChatRoomPartner {


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->

- 목업 데이터 타입 빌드 에러 복구

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #222 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- 기존에 퍼블리싱을 진행하며 생성한 목업 데이터에 대한 데이터타입 참조 오류 해결

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트
