### PR TITLE
[#228] feat(main): Server Time Store + Ticker 리팩토링 및 타이머 만료 시 데이터 갱신 구현

### DIFF
--- a/src/entities/auction/ui/auction-item-card/ui/auction-item-card.tsx
+++ b/src/entities/auction/ui/auction-item-card/ui/auction-item-card.tsx
@@ -17,6 +17,7 @@ export interface AuctionItemCardProps extends AuctionType {
   variant: AuctionCardVariantType;
   rank?: number;
   now: number;
+  onExpire?: () => void;
 }
 
 export function AuctionItemCard({
@@ -31,6 +32,7 @@ export function AuctionItemCard({
   startedAt,
   rank,
   now,
+  onExpire,
 }: AuctionItemCardProps) {
   const config = VARIANT_CONFIG[variant];
 
@@ -60,7 +62,9 @@ export function AuctionItemCard({
             <UpcomingInfo startedAt={startedAt} startPrice={startPrice} />
           )}
 
-          {config.timer && <AuctionTimer type={config.timer} now={now} startedAt={startedAt} />}
+          {config.timer && (
+            <AuctionTimer type={config.timer} now={now} startedAt={startedAt} onExpire={onExpire} />
+          )}
         </div>
       </Link>
 

--- a/src/entities/auction/ui/auction-item-card/ui/auction-item-card.tsx
+++ b/src/entities/auction/ui/auction-item-card/ui/auction-item-card.tsx
@@ -16,7 +16,6 @@ import UpcomingInfo from "@/entities/auction/ui/auction-item-card/ui/upcoming-in
 export interface AuctionItemCardProps extends AuctionType {
   variant: AuctionCardVariantType;
   rank?: number;
-  now: number;
   onExpire?: () => void;
 }
 
@@ -31,7 +30,6 @@ export function AuctionItemCard({
   isLiked,
   startedAt,
   rank,
-  now,
   onExpire,
 }: AuctionItemCardProps) {
   const config = VARIANT_CONFIG[variant];
@@ -63,7 +61,7 @@ export function AuctionItemCard({
           )}
 
           {config.timer && (
-            <AuctionTimer type={config.timer} now={now} startedAt={startedAt} onExpire={onExpire} />
+            <AuctionTimer type={config.timer} startedAt={startedAt} onExpire={onExpire} />
           )}
         </div>
       </Link>

--- a/src/entities/auction/ui/auction-item-card/ui/auction-timer.tsx
+++ b/src/entities/auction/ui/auction-item-card/ui/auction-timer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { Calendar, Timer, type LucideIcon } from "lucide-react";
 
+import { useServerTimeNow } from "@/shared/lib/hooks/use-server-time-now";
 import { calculateRemainingSeconds } from "@/shared/lib/utils/time/calc";
 import { formatRemaining } from "@/shared/lib/utils/time/format";
 
@@ -31,13 +32,14 @@ const AUCTION_TIMER_MAP: Record<
 
 interface AuctionTimerProps {
   type: AuctionTimerType;
-  now: number;
   startedAt: string;
   onExpire?: () => void;
 }
 
-export default function AuctionTimer({ type, now, startedAt, onExpire }: AuctionTimerProps) {
+export default function AuctionTimer({ type, startedAt, onExpire }: AuctionTimerProps) {
   const { label, ariaLabel, Icon } = AUCTION_TIMER_MAP[type];
+
+  const now = useServerTimeNow();
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);

--- a/src/entities/auction/ui/auction-item-card/ui/auction-timer.tsx
+++ b/src/entities/auction/ui/auction-item-card/ui/auction-timer.tsx
@@ -5,7 +5,10 @@ import { useEffect, useRef, useState } from "react";
 import { Calendar, Timer, type LucideIcon } from "lucide-react";
 
 import { useServerTimeNow } from "@/shared/lib/hooks/use-server-time-now";
-import { calculateRemainingSeconds } from "@/shared/lib/utils/time/calc";
+import {
+  calculateAuctionStartSeconds,
+  calculateNextPriceDropSeconds,
+} from "@/shared/lib/utils/time/calc";
 import { formatRemaining } from "@/shared/lib/utils/time/format";
 
 export type AuctionTimerType = "drop" | "start";
@@ -46,8 +49,8 @@ export default function AuctionTimer({ type, startedAt, onExpire }: AuctionTimer
 
   const remainSeconds =
     type === "drop"
-      ? calculateRemainingSeconds(now)
-      : calculateRemainingSeconds(now, Date.parse(startedAt));
+      ? calculateNextPriceDropSeconds(now)
+      : calculateAuctionStartSeconds(now, startedAt);
 
   const prevRemainSecondsRef = useRef<number | null>(null);
 
@@ -55,11 +58,7 @@ export default function AuctionTimer({ type, startedAt, onExpire }: AuctionTimer
     const prev = prevRemainSecondsRef.current;
     prevRemainSecondsRef.current = remainSeconds;
 
-    if (prev === null) return;
-
-    if (prev <= 1 && remainSeconds > prev) {
-      onExpire?.();
-    }
+    if (prev === 1) onExpire?.();
   }, [remainSeconds, onExpire]);
 
   const time = formatRemaining(remainSeconds);

--- a/src/entities/auction/ui/auction-item-carousel.tsx
+++ b/src/entities/auction/ui/auction-item-carousel.tsx
@@ -13,9 +13,10 @@ interface AuctionItemCarouselProps {
   items: AuctionType[];
   variant: AuctionCardVariantType;
   now: number;
+  onExpire?: () => void;
 }
 
-export function AuctionItemCarousel({ items, variant, now }: AuctionItemCarouselProps) {
+export function AuctionItemCarousel({ items, variant, now, onExpire }: AuctionItemCarouselProps) {
   return (
     <Carousel
       opts={{
@@ -35,6 +36,7 @@ export function AuctionItemCarousel({ items, variant, now }: AuctionItemCarousel
               variant={variant}
               rank={variant === "ranking" ? index + 1 : undefined}
               now={now}
+              onExpire={onExpire}
             />
           </CarouselItem>
         ))}

--- a/src/entities/auction/ui/auction-item-carousel.tsx
+++ b/src/entities/auction/ui/auction-item-carousel.tsx
@@ -12,11 +12,10 @@ import {
 interface AuctionItemCarouselProps {
   items: AuctionType[];
   variant: AuctionCardVariantType;
-  now: number;
   onExpire?: () => void;
 }
 
-export function AuctionItemCarousel({ items, variant, now, onExpire }: AuctionItemCarouselProps) {
+export function AuctionItemCarousel({ items, variant, onExpire }: AuctionItemCarouselProps) {
   return (
     <Carousel
       opts={{
@@ -35,7 +34,6 @@ export function AuctionItemCarousel({ items, variant, now, onExpire }: AuctionIt
               {...item}
               variant={variant}
               rank={variant === "ranking" ? index + 1 : undefined}
-              now={now}
               onExpire={onExpire}
             />
           </CarouselItem>

--- a/src/screens/main/model/sections.ts
+++ b/src/screens/main/model/sections.ts
@@ -1,0 +1,23 @@
+export const SECTIONS = [
+  {
+    key: "popularList",
+    title: "🔥 실시간 인기 랭킹",
+    description: "가장 인기있는 상품 모아보기!",
+    variant: "ranking",
+    moreHref: null,
+  },
+  {
+    key: "processList",
+    title: "⚡ 경매 진행 중",
+    description: "실시간 경매가 진행 중인 상품을 모아봤어요!",
+    variant: "live",
+    moreHref: "#",
+  },
+  {
+    key: "scheduledList",
+    title: "⏳ 경매 진행 예정",
+    description: "경매가 곧 진행될 거예요!",
+    variant: "upcoming",
+    moreHref: "#",
+  },
+] as const;

--- a/src/screens/main/ui/auctions-client.tsx
+++ b/src/screens/main/ui/auctions-client.tsx
@@ -1,37 +1,34 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { auctionsQuery } from "@/screens/main/model/auctions-query";
 import { SECTIONS } from "@/screens/main/model/sections";
-import { useServerTimeNow } from "@/shared/lib/hooks/use-server-time-now";
 import { useServerTimeStore } from "@/shared/lib/hooks/use-server-time-store";
+import { useServerTimeTicker } from "@/shared/lib/hooks/use-server-time-ticker";
 import { Container } from "@/shared/ui";
 import { AuctionCarouselSection } from "@/widgets/auction/auction-carousel-section";
 
 export default function AuctionsClient() {
-  const { data, isLoading, isError } = useQuery({
-    ...auctionsQuery,
-  });
+  const { data, isLoading, isError } = useQuery({ ...auctionsQuery });
 
   const queryClient = useQueryClient();
   const expireQueuedRef = useRef(false);
 
-  const setServerTime = useServerTimeStore((s) => s.setServerTime);
-  const now = useServerTimeNow();
+  const setServerTime = useServerTimeStore((state) => state.setServerTime);
+
+  useServerTimeTicker();
 
   useEffect(() => {
     const serverAt = data?.serverAt;
-
     if (!serverAt) return;
 
     setServerTime(serverAt);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data?.serverAt]);
+  }, [data?.serverAt, setServerTime]);
 
-  const handleExpire = () => {
+  const handleExpire = useCallback(() => {
     if (expireQueuedRef.current) return;
     expireQueuedRef.current = true;
 
@@ -39,7 +36,7 @@ export default function AuctionsClient() {
       expireQueuedRef.current = false;
       queryClient.invalidateQueries({ queryKey: auctionsQuery.queryKey });
     }, 0);
-  };
+  }, [queryClient]);
 
   return (
     <Container className="my-7 flex flex-col gap-15">
@@ -53,7 +50,6 @@ export default function AuctionsClient() {
           isLoading={isLoading}
           isError={isError}
           items={data?.[section.key]}
-          now={now}
           onExpire={handleExpire}
         />
       ))}

--- a/src/screens/main/ui/auctions-client.tsx
+++ b/src/screens/main/ui/auctions-client.tsx
@@ -5,34 +5,11 @@ import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { auctionsQuery } from "@/screens/main/model/auctions-query";
+import { SECTIONS } from "@/screens/main/model/sections";
 import { useServerTimeNow } from "@/shared/lib/hooks/use-server-time-now";
 import { useServerTimeStore } from "@/shared/lib/hooks/use-server-time-store";
 import { Container } from "@/shared/ui";
 import { AuctionCarouselSection } from "@/widgets/auction/auction-carousel-section";
-
-const SECTIONS = [
-  {
-    key: "popularList",
-    title: "🔥 실시간 인기 랭킹",
-    description: "가장 인기있는 상품 모아보기!",
-    variant: "ranking",
-    moreHref: null,
-  },
-  {
-    key: "processList",
-    title: "⚡ 경매 진행 중",
-    description: "실시간 경매가 진행 중인 상품을 모아봤어요!",
-    variant: "live",
-    moreHref: "#",
-  },
-  {
-    key: "scheduledList",
-    title: "⏳ 경매 진행 예정",
-    description: "경매가 곧 진행될 거예요!",
-    variant: "upcoming",
-    moreHref: "#",
-  },
-] as const;
 
 export default function AuctionsClient() {
   const { data, isLoading, isError } = useQuery({

--- a/src/shared/lib/hooks/use-server-time-now.ts
+++ b/src/shared/lib/hooks/use-server-time-now.ts
@@ -1,29 +1,5 @@
-"use client";
-
-import { useEffect, useRef, useState } from "react";
-
 import { useServerTimeStore } from "@/shared/lib/hooks/use-server-time-store";
-import { calculateServerNow } from "@/shared/lib/utils/time/calc";
 
 export function useServerTimeNow() {
-  const serverTimeOffset = useServerTimeStore((s) => s.serverTimeOffset);
-  const offsetRef = useRef(serverTimeOffset);
-
-  useEffect(() => {
-    offsetRef.current = serverTimeOffset;
-  }, [serverTimeOffset]);
-
-  const [now, setNow] = useState(() => calculateServerNow(offsetRef.current));
-
-  useEffect(() => {
-    const tick = () => setNow(calculateServerNow(offsetRef.current));
-
-    tick();
-
-    const id = globalThis.setInterval(tick, 1_000);
-
-    return () => globalThis.clearInterval(id);
-  }, []);
-
-  return now;
+  return useServerTimeStore((state) => state.serverNowMs);
 }

--- a/src/shared/lib/hooks/use-server-time-ticker.ts
+++ b/src/shared/lib/hooks/use-server-time-ticker.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+import { useServerTimeStore } from "@/shared/lib/hooks/use-server-time-store";
+
+export function useServerTimeTicker() {
+  const startTicker = useServerTimeStore((state) => state.startTicker);
+  const stopTicker = useServerTimeStore((state) => state.stopTicker);
+
+  useEffect(() => {
+    startTicker();
+
+    return () => stopTicker();
+  }, [startTicker, stopTicker]);
+}

--- a/src/shared/lib/stores/server-time-store.ts
+++ b/src/shared/lib/stores/server-time-store.ts
@@ -1,40 +1,66 @@
 import { createStore } from "zustand/vanilla";
 
-import { calculateServerNow } from "@/shared/lib/utils/time/calc";
+import { calculateServerTimeNow } from "@/shared/lib/utils/time/calc";
 
 export interface ServerTimeStore {
   serverTimeOffset: number;
   lastSyncServerTime: number | null;
+  serverNowMs: number;
+  tickerId: ReturnType<typeof globalThis.setInterval> | null;
 
   setServerTime: (serverTime: string) => void;
-
-  getCurrentServerTime: () => number;
+  updateServerNow: () => void;
+  startTicker: () => void;
+  stopTicker: () => void;
 }
 
 export const createServerTimeStore = () =>
   createStore<ServerTimeStore>()((set, get) => ({
     serverTimeOffset: 0,
     lastSyncServerTime: null,
+    serverNowMs: Date.now(),
+    tickerId: null,
 
     setServerTime: (serverTime: string) => {
       const serverTimeMs = Date.parse(serverTime);
-
       if (Number.isNaN(serverTimeMs)) return;
 
       const { lastSyncServerTime } = get();
       if (lastSyncServerTime === serverTimeMs) return;
 
       const clientTime = Date.now();
+      const offset = serverTimeMs - clientTime;
 
       set({
-        serverTimeOffset: serverTimeMs - clientTime,
+        serverTimeOffset: offset,
         lastSyncServerTime: serverTimeMs,
+        serverNowMs: calculateServerTimeNow(offset),
       });
     },
 
-    getCurrentServerTime: () => {
+    updateServerNow: () => {
       const { serverTimeOffset } = get();
+      set({ serverNowMs: calculateServerTimeNow(serverTimeOffset) });
+    },
 
-      return calculateServerNow(serverTimeOffset);
+    startTicker: () => {
+      const { tickerId } = get();
+      if (tickerId !== null) return;
+
+      get().updateServerNow();
+
+      const id = globalThis.setInterval(() => {
+        get().updateServerNow();
+      }, 1_000);
+
+      set({ tickerId: id });
+    },
+
+    stopTicker: () => {
+      const { tickerId } = get();
+      if (tickerId == null) return;
+
+      globalThis.clearInterval(tickerId);
+      set({ tickerId: null });
     },
   }));

--- a/src/shared/lib/utils/time/calc.ts
+++ b/src/shared/lib/utils/time/calc.ts
@@ -10,20 +10,11 @@ export function calcMsPercent(ms: number, durationMs: number) {
   return { progress, remain };
 }
 
-// REFACTOR: 검증 함수 공통 로직 분리
-export const calculateRemainingTimeToNextPriceDropMs = (nowMs: number, stepMs = 5 * 60 * 1000) => {
-  if (!Number.isFinite(nowMs) || !Number.isFinite(stepMs) || stepMs <= 0) return 0;
+export const calculateRemainingSeconds = (nowMs: number, stepMs = 5 * 60 * 1000) => {
+  const nextStepMs = Math.ceil(nowMs / stepMs) * stepMs;
+  const remainMs = Math.max(0, nextStepMs - nowMs);
 
-  const nextStepMs = (Math.floor(nowMs / stepMs) + 1) * stepMs;
-  return Math.max(0, nextStepMs - nowMs);
-};
-
-export const calculateRemainingTimeToAuctionStartMs = (nowMs: number, startAt: string) => {
-  const startAtMs = Date.parse(startAt);
-
-  if (Number.isNaN(startAtMs)) return 0;
-
-  return Math.max(0, startAtMs - nowMs);
+  return Math.max(0, Math.ceil(remainMs / 1000));
 };
 
 export const calculateServerNow = (offsetMs: number) => Date.now() + offsetMs;

--- a/src/shared/lib/utils/time/calc.ts
+++ b/src/shared/lib/utils/time/calc.ts
@@ -10,13 +10,23 @@ export function calcMsPercent(ms: number, durationMs: number) {
   return { progress, remain };
 }
 
-export const calculateRemainingSeconds = (nowMs: number, stepMs = 5 * 60 * 1000) => {
+export const calculateNextPriceDropSeconds = (nowMs: number, stepMs = 5 * 60 * 1000) => {
   if (!Number.isFinite(nowMs) || !Number.isFinite(stepMs) || stepMs <= 0) return 0;
 
-  const nextStepMs = Math.ceil(nowMs / stepMs) * stepMs;
+  const nextStepMs = (Math.floor(nowMs / stepMs) + 1) * stepMs;
   const remainMs = Math.max(0, nextStepMs - nowMs);
 
-  return Math.max(0, Math.ceil(remainMs / 1000));
+  return Math.ceil(remainMs / 1000);
+};
+
+export const calculateAuctionStartSeconds = (nowMs: number, startAt: string) => {
+  if (!Number.isFinite(nowMs)) return 0;
+
+  const startAtMs = Date.parse(startAt);
+  if (!Number.isFinite(startAtMs)) return 0;
+
+  const remainMs = Math.max(0, startAtMs - nowMs);
+  return Math.ceil(remainMs / 1000);
 };
 
 export const calculateServerTimeNow = (offsetMs: number) => Date.now() + offsetMs;

--- a/src/shared/lib/utils/time/calc.ts
+++ b/src/shared/lib/utils/time/calc.ts
@@ -11,10 +11,12 @@ export function calcMsPercent(ms: number, durationMs: number) {
 }
 
 export const calculateRemainingSeconds = (nowMs: number, stepMs = 5 * 60 * 1000) => {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(stepMs) || stepMs <= 0) return 0;
+
   const nextStepMs = Math.ceil(nowMs / stepMs) * stepMs;
   const remainMs = Math.max(0, nextStepMs - nowMs);
 
   return Math.max(0, Math.ceil(remainMs / 1000));
 };
 
-export const calculateServerNow = (offsetMs: number) => Date.now() + offsetMs;
+export const calculateServerTimeNow = (offsetMs: number) => Date.now() + offsetMs;

--- a/src/shared/lib/utils/time/format.ts
+++ b/src/shared/lib/utils/time/format.ts
@@ -24,10 +24,8 @@ export function formatMs(ms: number) {
   return `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
 }
 
-export function formatRemaining(ms: number) {
-  if (ms <= 0) return "0초";
-
-  const totalSeconds = Math.ceil(ms / 1000);
+export function formatRemaining(totalSeconds: number) {
+  if (totalSeconds <= 0) return "0초";
 
   const duration = dayjs.duration(totalSeconds, "seconds");
 

--- a/src/widgets/auction/auction-carousel-section/ui/auction-carousel-section.tsx
+++ b/src/widgets/auction/auction-carousel-section/ui/auction-carousel-section.tsx
@@ -16,7 +16,6 @@ interface AuctionCarouselSectionProps {
   isLoading: boolean;
   isError: boolean;
   items?: AuctionType[];
-  now: number;
   onExpire?: () => void;
 }
 
@@ -28,7 +27,6 @@ export function AuctionCarouselSection({
   isLoading,
   isError,
   items,
-  now,
   onExpire,
 }: AuctionCarouselSectionProps) {
   const hasItems = Array.isArray(items) && items.length > 0;
@@ -54,7 +52,7 @@ export function AuctionCarouselSection({
         />
       );
 
-    return <AuctionItemCarousel items={items} variant={variant} now={now} onExpire={onExpire} />;
+    return <AuctionItemCarousel items={items} variant={variant} onExpire={onExpire} />;
   };
 
   return (

--- a/src/widgets/auction/auction-carousel-section/ui/auction-carousel-section.tsx
+++ b/src/widgets/auction/auction-carousel-section/ui/auction-carousel-section.tsx
@@ -17,6 +17,7 @@ interface AuctionCarouselSectionProps {
   isError: boolean;
   items?: AuctionType[];
   now: number;
+  onExpire?: () => void;
 }
 
 export function AuctionCarouselSection({
@@ -28,6 +29,7 @@ export function AuctionCarouselSection({
   isError,
   items,
   now,
+  onExpire,
 }: AuctionCarouselSectionProps) {
   const hasItems = Array.isArray(items) && items.length > 0;
 
@@ -52,7 +54,7 @@ export function AuctionCarouselSection({
         />
       );
 
-    return <AuctionItemCarousel items={items} variant={variant} now={now} />;
+    return <AuctionItemCarousel items={items} variant={variant} now={now} onExpire={onExpire} />;
   };
 
   return (


### PR DESCRIPTION
## 📖 개요

Server Time Store + Ticker 리팩토링 및 타이머 만료 시 데이터 갱신 구현

## 📌 관련 이슈

- Close #228 

## 🛠️ 상세 작업 내용

### Timer 리팩토링

- `now` 드릴링을 제거하고 전역 서버 타임 스토어 + Ticker 방식으로 전환
- server time 갱신을 관리하는 `useServerTimeTicker` 훅 추가
- 관련 hook 및 store 로직을 ticker 기반으로 수정
- auction 관련 컴포넌트 props에서 `now` 제거

### 기타

- 사용하지 않는 `src/app/api-routes` 폴더 삭제
- SECTIONS 상수를 `src/screens/main/model/sections.ts` 파일로 분리
- `formatRemaining`의 파라미터를 `ms`에서 `totalSeconds`로 변경 후 로직 수정
- 가격 하락 남은 시간, 경매 시작 시간 계산 함수 `calculateRemainingSeconds`로 통합
- `invalidateQueries`를 사용해서 타이머 만료 시 데이터 갱신

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷

<img width="432" height="659" alt="스크린샷 2025-12-31 20 46 54" src="https://github.com/user-attachments/assets/a1c098fc-e590-4c65-8683-c94560c88a83" />

<img width="422" height="346" alt="스크린샷 2025-12-31 20 46 37" src="https://github.com/user-attachments/assets/0a969677-b37d-4316-8bba-f45281bcaccd" />

리팩토링 후 AuctionsClient부터 리렌더링 되는 문제가 해결되고 AuctionTimer만 리렌더링 되는 상태입니다.

## 👥 리뷰 확인 사항

- `onExpire` 콜백을 드릴링, 컨텍스트 방식 중 고민했으나 컨텍스트로 변경 시에 드는 코스트와 비교했을 때 이익이 크지 않아 드릴링으로 구현했습니다.
- 기존 코드에서 `now`와 `onExpire` 드릴링으로 `AuctionsClient`부터 하위 컴포넌트들이 리렌더링 되는 문제를 확인하고 전역 스토어를 구독하는 방식으로 리렌더링을 방지했습니다.
