### PR TITLE
[#159] refactor(user-page): align shared api client and proxy

### DIFF
--- a/src/shared/config/endpoints.ts
+++ b/src/shared/config/endpoints.ts
@@ -6,7 +6,7 @@ export const API_ENDPOINTS = {
   auctionEmoji: (auctionId: number | string, emojiType: "LIKE" | "FIRE" | "SAD" | "SMILE") =>
     `/api/v1/auctions/${auctionId}/emojis/${emojiType}`,
 
-  userInfo: (userid: number | string) => `/api/v1/users/${userid}`,
+  userInfo: (userid: number) => `/api/v1/users/${userid}`,
 
   tagSearch: "/api/v1/tags/search",
 


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- client.ts와 proxy / endpoint 설정을 수정

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #159 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- shared/api/client.ts
  - 공통 fetch / API client 로직 정리
  - user-page 관련 요청에서 일관된 호출 방식을 사용할 수 있도록 구조 정비

- shared/config/endpoints.ts
  - user 페이지에서 사용하는 endpoint 정의 정리
  - 이후 hook 및 화면 리팩토링에서 재사용 가능하도록 분리

- proxy.ts
  - user 페이지 API 요청 흐름에 맞게 proxy 경로 정리
  - client / server 간 요청 경로 일관성 확보

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷 (Optional)

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->

_N/A_

## ⚠️ 주의 사항 (Optional)

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->

_N/A_

## 👥 리뷰 확인 사항 (Optional)

<!-- 리뷰어가 집중해서 봐야 하는 부분이 있다면 작성해주세요 -->

_N/A_
