### PR TITLE
[#236] feat(login): route.ts cookie 옵션에 서브도메인 설정, userId 쿠키에 받아서 저장, regenerate-access-token api 호출

### DIFF
--- a/src/app/api/auth/callback/[provider]/route.ts
+++ b/src/app/api/auth/callback/[provider]/route.ts
@@ -8,7 +8,7 @@ const COOKIE_OPTIONS = {
     secure: isProduction,
     sameSite: isProduction ? ("none" as const) : ("lax" as const),
     path: "/",
-    maxAge: 60 * 60 * 24,
+    maxAge: 60 * 60,
     domain: isProduction ? ".wind-fall.store" : undefined,
   },
   REFRESH_TOKEN: {
@@ -80,7 +80,6 @@ export async function GET(
     }
 
     const result: ExchangeResponse = await response.json();
-
     const { accessToken, refreshToken, userId } = result.data;
 
     if (!accessToken || !refreshToken) {
@@ -92,10 +91,7 @@ export async function GET(
 
     nextResponse.cookies.set("accessToken", accessToken, COOKIE_OPTIONS.ACCESS_TOKEN);
     nextResponse.cookies.set("refreshToken", refreshToken, COOKIE_OPTIONS.REFRESH_TOKEN);
-
-    if (userId) {
-      nextResponse.cookies.set("userId", String(userId), COOKIE_OPTIONS.USER_ID);
-    }
+    nextResponse.cookies.set("userId", userId.toString(), COOKIE_OPTIONS.USER_ID);
 
     return nextResponse;
   } catch {

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
 const isProduction = process.env.NODE_ENV === "production";
 
 const COOKIE_OPTIONS = {
@@ -10,7 +11,7 @@ const COOKIE_OPTIONS = {
     secure: isProduction,
     sameSite: isProduction ? ("none" as const) : ("lax" as const),
     path: "/",
-    maxAge: 60 * 60 * 24,
+    maxAge: 60 * 60,
     domain: isProduction ? ".wind-fall.store" : undefined,
   },
   REFRESH_TOKEN: {
@@ -36,6 +37,7 @@ async function getRequestBody(req: NextRequest): Promise<{
   isFormData: boolean;
 }> {
   const contentType = req.headers.get("content-type");
+
   if (contentType?.includes("application/json")) {
     try {
       return { body: JSON.stringify(await req.json()), isFormData: false };
@@ -43,14 +45,17 @@ async function getRequestBody(req: NextRequest): Promise<{
       return { body: null, isFormData: false };
     }
   }
+
   if (contentType?.includes("multipart/form-data")) {
     try {
       const arrayBuffer = await req.arrayBuffer();
       return { body: arrayBuffer, isFormData: true };
-    } catch {
+    } catch (error) {
+      console.error("FormData 읽기 실패:", error);
       return { body: null, isFormData: false };
     }
   }
+
   const arrayBuffer = await req.arrayBuffer();
   return { body: arrayBuffer.byteLength > 0 ? arrayBuffer : null, isFormData: false };
 }
@@ -65,16 +70,13 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
   const { path } = await params;
 
   const pathString = path.join("/");
+  const searchParams = req.nextUrl.search;
+  const backendUrl = `${API_BASE_URL}/${pathString}${searchParams}`;
+
   const cookieStore = await cookies();
   const accessToken = cookieStore.get("accessToken")?.value;
   const refreshToken = cookieStore.get("refreshToken")?.value;
-  const backendUrlObj = new URL(`${API_BASE_URL}/${pathString}`);
 
-  req.nextUrl.searchParams.forEach((value, key) => {
-    backendUrlObj.searchParams.append(key, value);
-  });
-
-  const backendUrl = backendUrlObj.toString();
   const headers = new Headers(req.headers);
 
   // Authorization 헤더 설정
@@ -83,18 +85,25 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
   }
 
   headers.delete("host");
-  headers.delete("cookie");
+  headers.delete("cookie"); // 기존의 모든 쿠키 삭제 (보안 및 충돌 방지)
   headers.delete("content-length");
 
+  // 백엔드 @CookieValue 지원을 위해 쿠키 헤더 수동 재구성
   const backendCookies = [];
-
   if (accessToken) backendCookies.push(`accessToken=${accessToken}`);
   if (refreshToken) backendCookies.push(`refreshToken=${refreshToken}`);
+
   if (backendCookies.length > 0) {
     headers.set("Cookie", backendCookies.join("; "));
   }
 
   const requestBody = await getRequestBody(req);
+
+  // body 복사본 생성 (재사용 문제 해결)
+  let retryBody: string | ArrayBuffer | null = requestBody.body;
+  if (requestBody.body instanceof ArrayBuffer) {
+    retryBody = requestBody.body.slice(0);
+  }
 
   try {
     let backendRes = await fetch(backendUrl, {
@@ -114,7 +123,9 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
         cache: "no-store",
       });
 
+      // 토큰이 만료되었거나 문제가 있다면 삭제
       if (!refreshRes.ok) {
+        console.error("Refresh token failed or expired.");
         const response = NextResponse.json(
           { error: "Session expired. Please login again." },
           { status: 401 }
@@ -125,38 +136,33 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
 
       // Set-Cookie 헤더에서 새 accessToken 추출
       const setCookieHeaders = refreshRes.headers.get("set-cookie");
-      let newAccessToken: string = accessToken || "";
 
-      if (setCookieHeaders) {
-        const accessTokenMatch = setCookieHeaders.match(/accessToken=([^;]+)/);
-        if (accessTokenMatch) {
-          const [, newToken] = accessTokenMatch;
-          newAccessToken = newToken;
-        }
-      }
+      const [, token] = setCookieHeaders?.match(/accessToken=([^;]+)/) ?? [];
+
+      const newAccessToken: string | null = token ?? null;
 
       // accessToken을 찾지 못한 경우 에러 처리
       if (!newAccessToken) {
-        console.error("Failed to extract new access token from response");
+        console.error("Failed to extract new access token from Set-Cookie header");
         const response = NextResponse.json({ error: "Token refresh failed" }, { status: 401 });
         clearAuthCookies(response);
         return response;
       }
 
-      const newRefreshToken = refreshToken;
-      const userId = cookieStore.get("userId")?.value || "";
-
+      // 새로운 액세스 토큰으로 헤더 업데이트
       headers.set("Authorization", `Bearer ${newAccessToken}`);
 
+      // 재요청 시에도 쿠키 헤더 업데이트 필요
       const newBackendCookies = [];
-      newBackendCookies.push(`accessToken=${newAccessToken}`);
-      newBackendCookies.push(`refreshToken=${newRefreshToken}`);
-      headers.set("Cookie", newBackendCookies.join("; "));
+      if (newAccessToken) newBackendCookies.push(`accessToken=${newAccessToken}`);
+      if (newBackendCookies.length > 0) {
+        headers.set("Cookie", newBackendCookies.join("; "));
+      }
 
       backendRes = await fetch(backendUrl, {
         method: req.method,
         headers,
-        body: requestBody.body,
+        body: retryBody, // 복사본 사용
         cache: "no-store",
       });
 
@@ -173,10 +179,6 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
       });
 
       response.cookies.set("accessToken", newAccessToken, COOKIE_OPTIONS.ACCESS_TOKEN);
-      response.cookies.set("refreshToken", newRefreshToken, COOKIE_OPTIONS.REFRESH_TOKEN);
-      if (userId) {
-        response.cookies.set("userId", userId, COOKIE_OPTIONS.USER_ID);
-      }
 
       return response;
     }
@@ -185,7 +187,8 @@ async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ pa
       status: backendRes.status,
       headers: backendRes.headers,
     });
-  } catch {
+  } catch (error) {
+    console.error("Proxy Error:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
   }
 }
@@ -197,3 +200,128 @@ export {
   proxyHandler as DELETE,
   proxyHandler as PATCH,
 };
+
+// user-api가 accessToken이 아닌 cookie자체를 받아서 일단 주석처리
+// async function getRequestBody(req: NextRequest): Promise<string | ArrayBuffer | null> {
+//   const contentType = req.headers.get("content-type");
+
+//   if (contentType?.includes("application/json")) {
+//     try {
+//       return JSON.stringify(await req.json());
+//     } catch {
+//       return null;
+//     }
+//   }
+
+//   // 파일 업로드 등의 경우 ArrayBuffer로 처리
+//   const arrayBuffer = await req.arrayBuffer();
+//   return arrayBuffer.byteLength > 0 ? arrayBuffer : null;
+// }
+
+// function clearAuthCookies(response: NextResponse) {
+//   response.cookies.delete("accessToken");
+//   response.cookies.delete("refreshToken");
+// }
+
+// async function proxyHandler(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+//   const { path } = await params;
+
+//   const pathString = path.join("/");
+//   const searchParams = req.nextUrl.search;
+//   const backendUrl = `${API_BASE_URL}/${pathString}${searchParams}`;
+
+//   const cookieStore = await cookies();
+//   const accessToken = cookieStore.get("accessToken")?.value;
+//   const refreshToken = cookieStore.get("refreshToken")?.value;
+
+//   const headers = new Headers(req.headers);
+//   if (accessToken) {
+//     headers.set("Authorization", `Bearer ${accessToken}`);
+//   }
+
+//   // 불필요한 헤더 삭제, 재시도 시 문제 방지
+//   headers.delete("host");
+//   headers.delete("cookie");
+//   headers.delete("content-length");
+
+//   // Body 읽기, 한 번만 읽고 재사용
+//   const requestBody = await getRequestBody(req);
+
+//   try {
+//     let backendRes = await fetch(backendUrl, {
+//       method: req.method,
+//       headers,
+//       body: requestBody,
+//       cache: "no-store",
+//     });
+
+//     if (backendRes.status === 401 && refreshToken) {
+//       const refreshRes = await fetch(`${API_BASE_URL}/api/v1/auth/refresh`, {
+//         method: "POST",
+//         headers: { "Content-Type": "application/json" },
+//         body: JSON.stringify({ refreshToken }),
+//         cache: "no-store",
+//       });
+
+//       // 토큰이 만료되었거나 문제가 있다면 삭제
+//       if (!refreshRes.ok) {
+//         console.error("Refresh token failed or expired.");
+
+//         const response = NextResponse.json(
+//           { error: "Session expired. Please login again." },
+//           { status: 401 }
+//         );
+//         clearAuthCookies(response);
+//         return response;
+//       }
+
+//       const refreshData: RefreshResponse = await refreshRes.json();
+//       const newAccessToken = refreshData.data.accessToken;
+//       const newRefreshToken = refreshData.data.refreshToken;
+
+//       // 새로운 액세스 토큰으로 재요청
+//       headers.set("Authorization", `Bearer ${newAccessToken}`);
+
+//       backendRes = await fetch(backendUrl, {
+//         method: req.method,
+//         headers,
+//         body: requestBody,
+//         cache: "no-store",
+//       });
+
+//       if (backendRes.status === 401) {
+//         console.error("Request failed even after token refresh.");
+//         const response = NextResponse.json({ error: "Authentication failed" }, { status: 401 });
+//         clearAuthCookies(response);
+//         return response;
+//       }
+
+//       const response = new NextResponse(backendRes.body, {
+//         status: backendRes.status,
+//         headers: backendRes.headers,
+//       });
+
+//       response.cookies.set("accessToken", newAccessToken, COOKIE_OPTIONS.ACCESS_TOKEN);
+//       response.cookies.set("refreshToken", newRefreshToken, COOKIE_OPTIONS.REFRESH_TOKEN);
+
+//       return response;
+//     }
+
+//     return new NextResponse(backendRes.body, {
+//       status: backendRes.status,
+//       headers: backendRes.headers,
+//     });
+//   } catch (error) {
+//     console.error("Proxy Error:", error);
+//     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+//   }
+// }
+
+// // 모든 HTTP 요청에 대응
+// export {
+//   proxyHandler as GET,
+//   proxyHandler as POST,
+//   proxyHandler as PUT,
+//   proxyHandler as DELETE,
+//   proxyHandler as PATCH,
+// };


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 백엔드와 프론트 서브도메인을 같도록 해서 쿠키를 공유하도록 설정 추가
- userId를 받아서 httponly false 쿠키에 저장
- regenerate-access-token api 연결해서 토큰 재발급(refresh token은 재발급 하지 않아서 코드 수정)

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #236 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- Task

## ✅ PR 체크리스트

- [ ] 기능 테스트
- [ ] UI/레이아웃 확인
- [ ] 타입 정의 및 로직 셀프 리뷰
- [ ] 불필요한 주석 및 코드 제거
- [ ] `pnpm build` 로 실행 테스트
- [ ] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷 (Optional)

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->

_N/A_

## ⚠️ 주의 사항 (Optional)

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->

_N/A_

## 👥 리뷰 확인 사항 (Optional)

<!-- 리뷰어가 집중해서 봐야 하는 부분이 있다면 작성해주세요 -->

_N/A_
