### PR TITLE
[#285] feat(nav): 카테고리 네비게이션 기능 추가

### DIFF
--- a/src/widgets/category-nav/ui/category-nav-item.tsx
+++ b/src/widgets/category-nav/ui/category-nav-item.tsx
@@ -4,13 +4,12 @@ import { cn } from "@/shared/lib/utils/utils";
 import Button from "@/shared/ui/button/button";
 
 export interface CategoryNavItemProps {
-  href?: string;
+  href: string;
   label: string;
   isActive: boolean;
-  onClick?: () => void;
 }
 
-export function CategoryNavItem({ href = "#", label, isActive, onClick }: CategoryNavItemProps) {
+export function CategoryNavItem({ href, label, isActive }: CategoryNavItemProps) {
   return (
     <li className="flex h-full w-fit items-center">
       <Button
@@ -21,17 +20,7 @@ export function CategoryNavItem({ href = "#", label, isActive, onClick }: Catego
           isActive ? "border-brand text-brand-text" : "border-transparent"
         )}
       >
-        <Link
-          href={href}
-          aria-current={isActive ? "page" : undefined}
-          // TODO: API 연결 후 수정
-          onClick={(e) => {
-            if (href === "#") {
-              e.preventDefault();
-              onClick?.();
-            }
-          }}
-        >
+        <Link href={href} aria-current={isActive ? "page" : undefined}>
           {label}
         </Link>
       </Button>

--- a/src/widgets/category-nav/ui/category-nav.tsx
+++ b/src/widgets/category-nav/ui/category-nav.tsx
@@ -1,33 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 
 import {
   CATEGORY_LABEL,
   type CategoryFilter,
   FILTER_CATEGORIES,
 } from "@/entities/auction/model/category";
+import { ROUTES } from "@/shared/config/routes";
+import { Container } from "@/shared/ui";
 import { CategoryNavItem } from "@/widgets/category-nav/ui/category-nav-item";
 
-// TODO: usePathName 훅 사용해서 경로 받아오고 경로에 따라 보이게/안보이게
-// TODO: API 연결 후 주소 기반 수정
 export function CategoryNav() {
-  const [active, setActive] = useState<CategoryFilter | null>(null);
+  const categoryParam = useSearchParams().get("category");
+  const active = FILTER_CATEGORIES.includes(categoryParam as CategoryFilter)
+    ? (categoryParam as CategoryFilter)
+    : null;
 
   return (
     <nav aria-label="카테고리" className="bg-background h-header sticky top-0 z-50 border-b">
-      <div className="mx-auto max-w-7xl">
+      <Container className="p-0">
         <ul className="h-header scrollbar-hide flex overflow-x-auto whitespace-nowrap sm:justify-around sm:overflow-visible">
           {FILTER_CATEGORIES.map((category) => (
             <CategoryNavItem
               key={category}
               label={CATEGORY_LABEL[category]}
+              href={`${ROUTES.auctions}?category=${category}`}
               isActive={active === category}
-              onClick={() => setActive(category)}
             />
           ))}
         </ul>
-      </div>
+      </Container>
     </nav>
   );
 }


### PR DESCRIPTION
## 📖 개요

카테고리 네비게이션 기능 추가

## 📌 관련 이슈

- Close #285 

## 🛠️ 상세 작업 내용

- URL 파라미터 기반으로 카테고리 네비게이션 처리
- URL `searchParams`로 활성 카테고리 판별
- `CategoryNavItem`이 `href`를 필수로 받도록 변경
- 로컬 상태 변경을 위한 click 이벤트 처리 로직 제거
- 네비게이션 동작을 URL 기준으로 통일

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트