### PR TITLE
[#291] feat(search): HeaderSearch 컴포넌트 및 검색 기능 추가

### DIFF
--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -8,8 +8,8 @@ import Logo from "@/shared/assets/icons/windfall.svg";
 import { ROUTES } from "@/shared/config/routes";
 import { Container } from "@/shared/ui";
 import Button from "@/shared/ui/button/button";
-import SearchInput from "@/shared/ui/input/search-input";
 import HeaderActions from "@/widgets/header/ui/header-actions";
+import HeaderSearch from "@/widgets/header/ui/header-search";
 
 export async function Header() {
   const cookieStore = await cookies();
@@ -28,21 +28,13 @@ export async function Header() {
           </h1>
         </Link>
 
-        <form className="flex flex-1 items-center justify-center">
-          <div className="w-full max-w-135">
-            <label htmlFor="search" className="sr-only">
-              검색
-            </label>
-            {/* TODO: SearchInput 스타일 리팩토링 */}
-            <SearchInput id="search" />
-          </div>
-        </form>
+        <HeaderSearch />
 
         {hasValidUserId ? (
           <HeaderActions userId={numericUserId} />
         ) : (
           <Button asChild size="lg">
-            <Link href={ROUTES.login} aria-label="내 정보">
+            <Link href={ROUTES.login} aria-label="로그인">
               <LogIn className="size-5" />
               <span className="font-semibold">로그인</span>
             </Link>

--- a/src/widgets/header/ui/header-search.tsx
+++ b/src/widgets/header/ui/header-search.tsx
@@ -23,12 +23,12 @@ export default function HeaderSearch() {
   const applyQuery = (value: string) => {
     const trimmed = value.trim();
 
-    if (!trimmed) return;
-
     if (pathname === ROUTES.auctions) {
       setFilters({ query: trimmed });
       return;
     }
+
+    if (!trimmed) return;
 
     const params = new URLSearchParams();
     params.set("query", trimmed);


### PR DESCRIPTION
## 📖 개요

HeaderSearch 컴포넌트 및 검색 기능 추가

## 📌 관련 이슈

- Close #291 

## 🛠️ 상세 작업 내용

- 헤더 영역에서 경매 검색을 처리하는 HeaderSearch 컴포넌트 추가
- 검색어 입력을 auction filters와 연동해 query 파라미터로 반영
- 현재 pathname에 따라 라우트 이동 또는 필터 상태를 업데이트하도록 처리

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트
