### PR TITLE
[#304] feat(auction-purchase): 결제 confirm 라우트 핸들러에서 쿠키 전달 및 성공/실패 UX 개선

### DIFF
--- a/src/app/(protected)/payments/[id]/route.ts
+++ b/src/app/(protected)/payments/[id]/route.ts
@@ -14,6 +14,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
 
   if (!paymentKey || !orderId || !amount) {
     failUrl.searchParams.set("code", "MISS_ACCESS");
+    failUrl.searchParams.set("message", "결제 정보를 찾을 수 없어요");
     return NextResponse.redirect(failUrl);
   }
   const cookieHeader = req.headers.get("cookie") ?? "";
@@ -40,10 +41,11 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
     }
   } catch (error) {
     console.error(error);
-    failUrl.searchParams.set("code", "confirm");
+    failUrl.searchParams.set("code", "confirm-error");
+    failUrl.searchParams.set("message", "결제에 실패했어요");
     return NextResponse.redirect(failUrl);
   }
-  failUrl.searchParams.set("code", "what");
-
+  failUrl.searchParams.set("code", "confirm-error");
+  failUrl.searchParams.set("message", "결제에 실패했어요");
   return NextResponse.redirect(failUrl);
 }

--- a/src/screens/auction/auction-purchase/ui/AuctionPurchaseFailScreen.tsx
+++ b/src/screens/auction/auction-purchase/ui/AuctionPurchaseFailScreen.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+
+import { useNavigation } from "@/shared/lib/utils/navigation/navigation";
 
 export default function AuctionPurchaseFailScreen() {
   const searchParams = useSearchParams();
-
+  const { navigateToPrev, navigateToHome } = useNavigation();
   return (
     <div
       id="info"
@@ -41,23 +42,21 @@ export default function AuctionPurchaseFailScreen() {
       </div>
 
       <div className="flex-1 pr-6">
-        <Link href="https://docs.tosspayments.com/guides/v2/payment-widget/integration">
-          <button
-            className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
-            type="button"
-          >
-            연동 문서
-          </button>
-        </Link>
-        <Link href="https://discord.gg/A4fRFXQhRu">
-          <button
-            type="button"
-            className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
-            style={{ backgroundColor: "#e8f3ff", color: "#1b64da" }}
-          >
-            실시간 문의
-          </button>
-        </Link>
+        <button
+          className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
+          type="button"
+          onClick={() => navigateToPrev()}
+        >
+          이전으로
+        </button>
+        <button
+          type="button"
+          className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
+          style={{ backgroundColor: "#e8f3ff", color: "#1b64da" }}
+          onClick={() => navigateToHome()}
+        >
+          홈으로
+        </button>
       </div>
     </div>
   );

--- a/src/screens/auction/auction-purchase/ui/AuctionPurchaseSuccessScreen.tsx
+++ b/src/screens/auction/auction-purchase/ui/AuctionPurchaseSuccessScreen.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+
+import { useNavigation } from "@/shared/lib/utils/navigation/navigation";
 
 export default function AuctionPurchaseSuccessScreen() {
   const searchParams = useSearchParams();
-
+  const { navigateToHome, navigateToPrev } = useNavigation();
   return (
     <div>
       <div
@@ -58,23 +59,21 @@ export default function AuctionPurchaseSuccessScreen() {
           </div>
         </div>
         <div className="flex-1 pr-6">
-          <Link href="https://docs.tosspayments.com/guides/v2/payment-widget/integration">
-            <button
-              className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
-              type="button"
-            >
-              연동 문서
-            </button>
-          </Link>
-          <Link href="https://discord.gg/A4fRFXQhRu">
-            <button
-              type="button"
-              className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
-              style={{ backgroundColor: "#e8f3ff", color: "#1b64da" }}
-            >
-              실시간 문의
-            </button>
-          </Link>
+          <button
+            className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
+            type="button"
+            onClick={() => navigateToPrev()}
+          >
+            이전으로
+          </button>
+          <button
+            type="button"
+            onClick={() => navigateToHome()}
+            className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
+            style={{ backgroundColor: "#e8f3ff", color: "#1b64da" }}
+          >
+            홈으로
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

결제 위젯 승인 이후 /payments/[id]/route.ts 라우트 핸들러에서 브라우저 쿠키를 백엔드 confirm API로 전달하도록 수정했고, 결제 성공/실패 화면에 이동 버튼/안내 메시지를 보강했습니다.

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #304

## 🛠️ 상세 작업 내용

결제 confirm 라우트 핸들러
	•	req.headers.get("cookie")를 읽어 백엔드 요청 헤더에 Cookie로 전달
	•	결제 정보 누락 시 fail redirect 시 code, message query 파라미터 추가
	•	에러 발생 시 fail redirect 시 code, message 정리
	•	성공 조건을 response.data 기반으로 통일

결제 성공/실패 화면 UX
	•	성공/실패 화면에 버튼 및 네비게이션 동작 추가/정리
	•	이전으로 / 홈으로
	•	연동 문서 / 실시간 문의 링크 유지

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트