### PR TITLE
[#331] fix(time): 타이머 포맷 utc 제거

### DIFF
--- a/src/entities/auction/ui/auction-item-card/ui/upcoming-info.tsx
+++ b/src/entities/auction/ui/auction-item-card/ui/upcoming-info.tsx
@@ -11,7 +11,7 @@ export default function UpcomingInfo({ startedAt, startPrice }: UpcomingInfoProp
       <dt className="text-muted-foreground">경매 시작</dt>
       <dd className="text-muted-foreground text-right">
         <time dateTime={startedAt}>
-          {dayjs.utc(startedAt).tz("Asia/Seoul").format("M월 D일 HH시 mm분")}
+          {dayjs.tz(startedAt, "Asia/Seoul").format("M월 D일 HH시 mm분")}
         </time>
       </dd>
 


### PR DESCRIPTION
## 📖 개요

타이머 포맷 utc 제거

## 📌 관련 이슈

- Close #331 

## 🛠️ 상세 작업 내용

- 경매 타이머 `utc` 제거

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

