### PR TITLE
[#338] fix(upload-image): 이미지 업로드에 대한 파일 크기 검증 로직 변경

### DIFF
--- a/src/features/auction/auction-create/api/use-upload-auction-images.ts
+++ b/src/features/auction/auction-create/api/use-upload-auction-images.ts
@@ -40,18 +40,10 @@ export function useUploadAuctionImages() {
           case 400:
           case 404:
           case 502:
-            showToast.error(apiError.message);
-            break;
-          // 권한 문제
-          case 403:
-            showToast.error("이미지 업로드 권한이 없습니다.");
-            break;
-          // TODO: 413 이미지 파일 크기 관련 에러 message 업데이트 예정
-          case 413:
-            showToast.error("이미지 파일은 최대 50MB까지 업로드할 수 있습니다.");
+            showToast.error(apiError.message || "이미지 업로드에 실패했습니다.");
             break;
           default:
-            showToast.error(apiError.message || "이미지 업로드에 실패했습니다.");
+            showToast.error("이미지 업로드에 실패했습니다.");
         }
       }
     },

--- a/src/features/auction/auction-create/ui/image-upload-section.tsx
+++ b/src/features/auction/auction-create/ui/image-upload-section.tsx
@@ -10,7 +10,10 @@ import {
   ImagePreviewItem,
   ImageCarouselView,
 } from "@/entities/auction";
-import { validateImageFiles } from "@/shared/lib/utils/image-validation/image-validation";
+import {
+  validateImageFiles,
+  MAX_TOTAL_IMAGE_SIZE,
+} from "@/shared/lib/utils/image-validation/image-validation";
 import { showToast } from "@/shared/lib/utils/toast/show-toast";
 import FileInput from "@/shared/ui/input/file-input";
 
@@ -43,7 +46,27 @@ export function ImageUploadSection({ images, onImagesChange }: ImageUploadSectio
 
       if (validationResult.oversizedFiles.length > 0) {
         const fileNames = validationResult.oversizedFiles.map((file) => file.name).join(", ");
-        showToast.error(`파일 크기는 50MB를 초과할 수 없습니다. (${fileNames})`);
+        showToast.error(
+          `이미지 파일은 하나당 최대 파일 크기는 10MB를 초과할 수 없습니다. (${fileNames})`
+        );
+        return;
+      }
+
+      // 기존 이미지들의 총 크기 계산
+      const existingImagesTotalSize = currentImages.reduce(
+        (sum, image) => sum + (image.file?.size || 0),
+        0
+      );
+
+      // 새로 추가할 파일들의 총 크기
+      const newFilesTotalSize = validationResult.validFiles.reduce(
+        (sum, file) => sum + file.size,
+        0
+      );
+
+      // 이미지의 총 크기가 50MB를 초과하는지 검증
+      if (existingImagesTotalSize + newFilesTotalSize > MAX_TOTAL_IMAGE_SIZE) {
+        showToast.error(`전체 이미지 파일 크기는 50MB를 초과할 수 없습니다.`);
         return;
       }
 

--- a/src/features/chat/api/upload-chat-images.ts
+++ b/src/features/chat/api/upload-chat-images.ts
@@ -43,12 +43,11 @@ export function useUploadChatImages() {
           case 403:
             showToast.error("이미지 업로드 권한이 없습니다.");
             break;
-          // TODO: 413 이미지 파일 크기 관련 에러 message 업데이트 예정
           case 413:
-            showToast.error("이미지 파일은 최대 50MB까지 업로드할 수 있습니다.");
+            showToast.error("이미지 파일은 하나당 최대 파일 크기는 10MB를 초과할 수 없습니다.");
             break;
           default:
-            showToast.error(apiError.message || "이미지 업로드에 실패했습니다.");
+            showToast.error("이미지 업로드에 실패했습니다.");
         }
       }
     },

--- a/src/features/chat/ui/chat-detail.tsx
+++ b/src/features/chat/ui/chat-detail.tsx
@@ -83,7 +83,13 @@ function ChatDetailComponent({
 
     if (validationResult.oversizedFiles.length > 0) {
       const fileNames = validationResult.oversizedFiles.map((file) => file.name).join(", ");
-      showToast.error(`파일 크기는 50MB를 초과할 수 없습니다. (${fileNames})`);
+      showToast.error(`이미지 하나당 최대 파일 크기는 10MB를 초과할 수 없습니다. (${fileNames})`);
+      return;
+    }
+
+    // 총 크기 검증 (50MB 제한)
+    if (validationResult.totalSizeExceeded) {
+      showToast.error(`전체 이미지 파일 크기는 50MB를 초과할 수 없습니다.`);
       return;
     }
 

--- a/src/shared/lib/utils/image-validation/image-validation.ts
+++ b/src/shared/lib/utils/image-validation/image-validation.ts
@@ -1,11 +1,6 @@
-export const MAX_IMAGE_FILE_SIZE = 50 * 1024 * 1024; // 50MB
-export const ALLOWED_IMAGE_TYPES = [
-  "image/jpeg",
-  "image/jpg",
-  "image/png",
-  "image/gif",
-  "image/webp",
-];
+export const MAX_IMAGE_FILE_SIZE = 10 * 1024 * 1024; // 10MB (개별 파일 최대 크기)
+export const MAX_TOTAL_IMAGE_SIZE = 50 * 1024 * 1024; // 50MB (전체 이미지 총 크기 제한)
+export const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 export const ALLOWED_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
 
 export const isValidImageFile = (file: File): boolean => {
@@ -31,11 +26,14 @@ export interface ImageValidationResult {
   validFiles: File[];
   invalidTypeFiles: File[];
   oversizedFiles: File[];
+  totalSizeExceeded?: boolean;
+  totalSize?: number;
 }
 
 export const validateImageFiles = (
   files: File[],
-  maxSize: number = MAX_IMAGE_FILE_SIZE
+  maxSize: number = MAX_IMAGE_FILE_SIZE,
+  maxTotalSize: number = MAX_TOTAL_IMAGE_SIZE
 ): ImageValidationResult => {
   const invalidTypeFiles: File[] = [];
   const oversizedFiles: File[] = [];
@@ -51,9 +49,15 @@ export const validateImageFiles = (
     }
   });
 
+  // 총 크기 계산
+  const totalSize = validFiles.reduce((sum, file) => sum + file.size, 0);
+  const totalSizeExceeded = totalSize > maxTotalSize;
+
   return {
     validFiles,
     invalidTypeFiles,
     oversizedFiles,
+    totalSizeExceeded,
+    totalSize,
   };
 };


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->

- 이미지 업로드에 대한 파일 크기 검증 로직 변경

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #338 

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- 이미지 업로드 시 하나의 파일의 최대 크기는 10MB로 제한, 총 이미지 파일은 50MB 미만으로 설정
- 경매 등록 하나의 이미지 파일 크기 제한 10MB, 최대 10장 50MB까지 검증 로직 추가
- 채팅에서 이미지 전송 시 하나의 이미지 파일 크기 제한 10MB, 최대 5장 50MB까지 검증 로직 추가

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트