### PR TITLE
fix(users): 판매, 구매에서 unread 표시 문제, 판매-구매-찜 갱신

### DIFF
--- a/src/features/auction/auction-create/api/use-create-auction.ts
+++ b/src/features/auction/auction-create/api/use-create-auction.ts
@@ -1,9 +1,10 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { httpClient } from "@/shared/api/client";
 import { dayjs } from "@/shared/lib/utils/dayjs";
 import { showToast } from "@/shared/lib/utils/toast/show-toast";
 
+import { userSaleKeys } from "../../auction-sale/api/use-sales"; // users 판매 목록 갱신
 import { combineDateTime } from "../utils/date-utils";
 
 import type {
@@ -43,6 +44,7 @@ const transformFormDataToApiRequest = ({
 });
 
 export function useCreateAuction() {
+  const queryClient = useQueryClient(); // users 판매 목록 갱신
   return useMutation<CreateAuctionResponseData, Error, CreateAuctionParams>({
     mutationFn: async (params) => {
       const requestBody = transformFormDataToApiRequest(params);
@@ -58,6 +60,7 @@ export function useCreateAuction() {
     },
     onSuccess: (_data) => {
       showToast.success("경매가 성공적으로 등록되었습니다.");
+      queryClient.invalidateQueries({ queryKey: userSaleKeys.all }); // users 판매 목록 갱신
     },
     onError: (error) => {
       showToast.error("경매 등록에 실패했습니다. 다시 시도해주세요.");

--- a/src/features/auction/auction-like/hook/use-auction-like.ts
+++ b/src/features/auction/auction-like/hook/use-auction-like.ts
@@ -9,6 +9,8 @@ import type { LikeType } from "@/features/auction/auction-like/model/types";
 import { useIsAuthenticated } from "@/features/auth/api/use-is-authenticated";
 import { showToast } from "@/shared/lib/utils/toast/show-toast";
 
+import { userAuctionLikeKeys } from "../api/use-auction-like"; // users 찜 목록 갱신
+
 interface UseAuctionLikeType {
   auctionId: string | number;
   initIsLiked: boolean;
@@ -48,6 +50,7 @@ export const useAuctionLike = ({ auctionId, initIsLiked, initLikeCount }: UseAuc
 
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: userAuctionLikeKeys.all }); // users 찜 목록 갱신
     },
   });
 

--- a/src/features/auction/auction-sale/api/use-sales.ts
+++ b/src/features/auction/auction-sale/api/use-sales.ts
@@ -16,8 +16,7 @@ interface SalesSliceItem {
   endPrice?: number;
   discountPercent?: number;
   startedAt: string;
-  chatRoomId?: number;
-  unreadCount?: number;
+  chatInfo?: { roomId: number; unreadCount: number };
 }
 
 interface SalesData {
@@ -63,8 +62,8 @@ const getUserSalesList = async (userId: number): Promise<UserSellingItemType[]> 
         discountRate: item.discountPercent ?? 0,
         status: mapStatusToTradeStatus(item.status),
         date: dayjs(item.startedAt).format("YYYY-MM-DD"),
-        chatRoomId: item.chatRoomId ?? 0,
-        unreadMessageCount: item.unreadCount ?? 0,
+        chatRoomId: item.chatInfo?.roomId,
+        unreadMessageCount: item.chatInfo?.unreadCount,
       };
     });
 };

--- a/src/features/auction/auction-sale/ui/user-selling-item-card.tsx
+++ b/src/features/auction/auction-sale/ui/user-selling-item-card.tsx
@@ -82,9 +82,9 @@ export function UserSellingItemCard({
                 {hasUnreadMessages && (
                   <span
                     className="text-2.5 ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-white/20 px-1 text-white"
-                    aria-label={`${hasUnreadMessages}개의 읽지 않은 메시지`}
+                    aria-label={`${item.unreadMessageCount}개의 읽지 않은 메시지`}
                   >
-                    {hasUnreadMessages}
+                    {item.unreadMessageCount}
                   </span>
                 )}
               </Link>

--- a/src/features/purchase/ui/purchased-item-card.tsx
+++ b/src/features/purchase/ui/purchased-item-card.tsx
@@ -35,63 +35,50 @@ export function UserPurchasedItemCard({
       badgeNode={<UserItemBadge status={item.status} />}
       footerNode={
         <div className="-mt-1 flex w-full items-center gap-2">
+          <Button
+            variant={hasUnreadMessages ? "primary" : "outline"}
+            className="h-9 flex-1 gap-1"
+            asChild
+          >
+            <Link href="/dm" onClick={(e) => e.stopPropagation()}>
+              <MessageCircle className="size-4" />
+              <span className="text-sm">1:1 채팅</span>
+              {hasUnreadMessages && (
+                <span
+                  className="text-2.5 ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-white/20 px-1 text-white"
+                  aria-label={`${item.unreadMessageCount}개의 읽지 않은 메시지`}
+                  role="status"
+                >
+                  {item.unreadMessageCount}
+                </span>
+              )}
+            </Link>
+          </Button>
+
           {isConfirmed ? (
-            <>
-              <Button
-                variant={hasUnreadMessages ? "primary" : "outline"}
-                className="h-9 flex-1 gap-1"
-                asChild
-              >
-                <Link href="/dm" onClick={(e) => e.stopPropagation()}>
-                  <MessageCircle className="size-4" />
-                  <span className="text-sm">1:1 채팅</span>
-                  {hasUnreadMessages && (
-                    <span
-                      className="text-2.5 ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-white/20 px-1 text-white"
-                      aria-label={`${hasUnreadMessages}개의 읽지 않은 메시지`}
-                      role="status"
-                    >
-                      {hasUnreadMessages}
-                    </span>
-                  )}
-                </Link>
-              </Button>
-              <Button
-                variant="outline"
-                className="h-9 flex-1 gap-1"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onReviewClick?.(item);
-                }}
-              >
-                <Star className="size-4" />
-                <span className="text-sm">{item.hasReview ? "리뷰 수정" : "리뷰 작성"}</span>
-              </Button>
-            </>
+            <Button
+              variant="outline"
+              className="h-9 flex-1 gap-1"
+              onClick={(e) => {
+                e.stopPropagation();
+                onReviewClick?.(item);
+              }}
+            >
+              <Star className="size-4" />
+              <span className="text-sm">{item.hasReview ? "리뷰 수정" : "리뷰 작성"}</span>
+            </Button>
           ) : (
-            <>
-              <Button
-                variant="outline"
-                className="h-9 flex-1 gap-1"
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-              >
-                <MessageCircle className="size-4" />
-                <span className="text-sm">1:1 채팅</span>
-              </Button>
-              <Button
-                variant="outline"
-                className="h-9 flex-1 gap-1"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onConfirm?.(item);
-                }}
-              >
-                <Check className="size-4" />
-                <span className="text-sm">구매 확정</span>
-              </Button>
-            </>
+            <Button
+              variant="outline"
+              className="h-9 flex-1 gap-1"
+              onClick={(e) => {
+                e.stopPropagation();
+                onConfirm?.(item);
+              }}
+            >
+              <Check className="size-4" />
+              <span className="text-sm">구매 확정</span>
+            </Button>
           )}
         </div>
       }

--- a/src/screens/auction/auction-purchase/ui/AuctionPurchaseSuccessScreen.tsx
+++ b/src/screens/auction/auction-purchase/ui/AuctionPurchaseSuccessScreen.tsx
@@ -1,13 +1,25 @@
 "use client";
 
+import { useEffect } from "react"; // users 구매 목록 갱신
+
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 
+import { useQueryClient } from "@tanstack/react-query"; // users 구매 목록 갱신
+
+import { purchaseKeys } from "@/features/purchase/api/use-purchases"; // users 구매 목록 갱신
 import { useNavigation } from "@/shared/lib/utils/navigation/navigation";
 
 export default function AuctionPurchaseSuccessScreen() {
   const searchParams = useSearchParams();
   const { navigateToHome, navigateToPrev } = useNavigation();
+
+  // users 구매 목록 갱신
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: purchaseKeys.all });
+  }, [queryClient]);
+
   return (
     <div>
       <div


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- 구매 목록에서 확정이 아니여도 1:1 DM 이동 가능
- 판매/구매 목록 unreadMessage 표시 버그
- 판매/구매/찜 갱신에 users page 쿼리 갱신

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- Task

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [ ] 타입 정의 및 로직 셀프 리뷰
- [ ] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷 (Optional)

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->

_N/A_

## ⚠️ 주의 사항 (Optional)

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->

_N/A_

## 👥 리뷰 확인 사항 (Optional)

<!-- 리뷰어가 집중해서 봐야 하는 부분이 있다면 작성해주세요 -->

_N/A_
