### PR TITLE
fix(pay-error-page): 결제 실패 페이지 버튼 정렬 수정 및 gap 추가

### DIFF
--- a/src/screens/auction/auction-purchase/ui/AuctionPurchaseFailScreen.tsx
+++ b/src/screens/auction/auction-purchase/ui/AuctionPurchaseFailScreen.tsx
@@ -41,7 +41,7 @@ export default function AuctionPurchaseFailScreen() {
         <div className="flex-1 pr-6 text-right" id="code">{`${searchParams.get("code")}`}</div>
       </div>
 
-      <div className="flex flex-1 justify-center gap-2">
+      <div className="flex justify-center gap-2">
         <button
           className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
           type="button"

--- a/src/screens/auction/auction-purchase/ui/AuctionPurchaseFailScreen.tsx
+++ b/src/screens/auction/auction-purchase/ui/AuctionPurchaseFailScreen.tsx
@@ -41,7 +41,7 @@ export default function AuctionPurchaseFailScreen() {
         <div className="flex-1 pr-6 text-right" id="code">{`${searchParams.get("code")}`}</div>
       </div>
 
-      <div className="flex-1 pr-6">
+      <div className="flex flex-1 justify-center gap-2">
         <button
           className="mt-[30px] w-[250px] max-w-[41.66667%] flex-[0_0_41.66667%] cursor-pointer rounded-[7px] border-0 border-transparent bg-[#3182f6] px-4 py-[11px] text-center text-[15px] leading-[18px] font-semibold whitespace-nowrap text-[#f9fafb] no-underline transition-[background,color] duration-200 ease-in select-none"
           type="button"


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->

- 결제 실패 페이지 버튼 정렬 수정 및 gap 추가

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- 결제 실패 페이지 버튼 정렬 수정 및 gap 추가

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷 (Optional)

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->

<img width="555" height="367" alt="image" src="https://github.com/user-attachments/assets/29a94a19-84e2-4767-9cb1-04f9a71e9553" />

