### PR TITLE
fix(query): 좋아요/알림 액션에 query cache 업데이트 추가

### DIFF
--- a/src/features/auction/auction-like/hook/use-auction-like.ts
+++ b/src/features/auction/auction-like/hook/use-auction-like.ts
@@ -1,12 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { toggleAuctionLike } from "@/features/auction/auction-like/api/like";
 import type { LikeType } from "@/features/auction/auction-like/model/types";
 import { useIsAuthenticated } from "@/features/auth/api/use-is-authenticated";
+import {
+  getAuctionsCacheSnapshot,
+  restoreAuctionsCache,
+  updateAuctionsCache,
+} from "@/shared/lib/query/update-auctions-cache";
 import { showToast } from "@/shared/lib/utils/toast/show-toast";
 
 import { userAuctionLikeKeys } from "../api/use-auction-like"; // users 찜 목록 갱신
@@ -28,6 +33,16 @@ export const useAuctionLike = ({ auctionId, initIsLiked, initLikeCount }: UseAuc
 
   const queryKey = ["auction-like", auctionId] as const;
 
+  useEffect(() => {
+    setState((prev) => {
+      const nextLikeCount = initLikeCount ?? prev.likeCount;
+      if (prev.isLiked === initIsLiked && prev.likeCount === nextLikeCount) {
+        return prev;
+      }
+      return { isLiked: initIsLiked, likeCount: nextLikeCount };
+    });
+  }, [initIsLiked, initLikeCount]);
+
   const likeMutation = useMutation({
     mutationFn: () => toggleAuctionLike(auctionId),
 
@@ -35,17 +50,26 @@ export const useAuctionLike = ({ auctionId, initIsLiked, initLikeCount }: UseAuc
       await queryClient.cancelQueries({ queryKey });
 
       const prev = state;
+      const snapshot = getAuctionsCacheSnapshot(queryClient);
+      const nextIsLiked = !state.isLiked;
+
+      updateAuctionsCache(queryClient, auctionId, { isLiked: nextIsLiked });
       setState((s) => ({
         isLiked: !s.isLiked,
         likeCount: s.likeCount + (s.isLiked ? -1 : 1),
       }));
 
-      return { prev };
+      return { prev, snapshot };
     },
 
     onError: (_err, _vars, ctx) => {
       if (ctx?.prev) setState(ctx.prev);
+      restoreAuctionsCache(queryClient, ctx?.snapshot);
       showToast.error("찜 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    },
+
+    onSuccess: (data) => {
+      updateAuctionsCache(queryClient, auctionId, { isLiked: data.isLiked });
     },
 
     onSettled: () => {

--- a/src/shared/lib/query/update-auctions-cache.ts
+++ b/src/shared/lib/query/update-auctions-cache.ts
@@ -1,0 +1,111 @@
+import type { AuctionType } from "@/entities/auction/model/types";
+import type { AuctionListData } from "@/screens/auction/auction-list/model/types";
+import type { AuctionsData } from "@/screens/main/model/types";
+
+import type { InfiniteData, QueryClient, QueryKey } from "@tanstack/react-query";
+
+type AuctionCachePatch = Partial<Pick<AuctionType, "isLiked" | "isNotification">>;
+
+export interface AuctionsCacheSnapshot {
+  auctionsData?: AuctionsData;
+  searchQueries: [QueryKey, InfiniteData<AuctionListData> | undefined][];
+}
+
+function updateListItem<T extends { auctionId: number }>(
+  list: T[],
+  auctionId: number | string,
+  patch: AuctionCachePatch
+) {
+  const index = list.findIndex((item) => String(item.auctionId) === String(auctionId));
+  if (index === -1) {
+    return { next: list, changed: false };
+  }
+
+  const next = list.slice();
+  next[index] = { ...next[index], ...patch };
+  return { next, changed: true };
+}
+
+function updateMainAuctionsData(
+  data: AuctionsData,
+  auctionId: number | string,
+  patch: AuctionCachePatch
+) {
+  const popular = updateListItem(data.popularList, auctionId, patch);
+  const process = updateListItem(data.processList, auctionId, patch);
+  const scheduled = updateListItem(data.scheduledList, auctionId, patch);
+
+  if (!popular.changed && !process.changed && !scheduled.changed) {
+    return data;
+  }
+
+  return {
+    ...data,
+    popularList: popular.next,
+    processList: process.next,
+    scheduledList: scheduled.next,
+  };
+}
+
+function updateSearchAuctionsData(
+  data: InfiniteData<AuctionListData>,
+  auctionId: number | string,
+  patch: AuctionCachePatch
+) {
+  let changed = false;
+  const pages = data.pages.map((page) => {
+    const updated = updateListItem(page.slice, auctionId, patch);
+    if (!updated.changed) return page;
+    changed = true;
+    return { ...page, slice: updated.next };
+  });
+
+  if (!changed) return data;
+
+  return { ...data, pages };
+}
+
+export function getAuctionsCacheSnapshot(queryClient: QueryClient): AuctionsCacheSnapshot {
+  return {
+    auctionsData: queryClient.getQueryData<AuctionsData>(["auctions"]),
+    searchQueries: queryClient.getQueriesData<InfiniteData<AuctionListData>>({
+      queryKey: ["auctions", "search"],
+    }),
+  };
+}
+
+export function restoreAuctionsCache(
+  queryClient: QueryClient,
+  snapshot: AuctionsCacheSnapshot | undefined
+) {
+  if (!snapshot) return;
+
+  if (snapshot.auctionsData !== undefined) {
+    queryClient.setQueryData(["auctions"], snapshot.auctionsData);
+  }
+
+  snapshot.searchQueries.forEach(([key, data]) => {
+    if (data !== undefined) {
+      queryClient.setQueryData(key, data);
+    }
+  });
+}
+
+export function updateAuctionsCache(
+  queryClient: QueryClient,
+  auctionId: number | string,
+  patch: AuctionCachePatch
+) {
+  queryClient.setQueryData<AuctionsData>(["auctions"], (data) => {
+    if (!data) return data;
+    return updateMainAuctionsData(data, auctionId, patch);
+  });
+
+  queryClient.setQueriesData<InfiniteData<AuctionListData>>(
+    { queryKey: ["auctions", "search"] },
+    (data) => {
+      if (!data) return data;
+      return updateSearchAuctionsData(data, auctionId, patch);
+    }
+  );
+}


### PR DESCRIPTION
## 📖 개요

좋아요/알림 액션에 query cache 업데이트 추가

## 📌 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- 경매 좋아요, 알림 토글을 위한 optimistic cache 업데이트 유틸 추가
- 실패 시 이전 상태로 복구하는 rollback 로직 함께 구현
- 관련 훅과 컴포넌트에서 공용 유틸을 사용하도록 연결
- 좋아요/알림 UI 반응성을 즉시 반영하도록 동작 개선

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트
