### PR TITLE
[#356] feat(auth): 로그아웃 API 추가 및 헤더 사용자 메뉴 드롭다운 구현

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+import { clearAuthCookies } from "@/shared/lib/utils/auth/cookie-options";
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+
+  clearAuthCookies(response);
+
+  return response;
+}

--- a/src/features/auction/auction-like/hook/use-auction-like.ts
+++ b/src/features/auction/auction-like/hook/use-auction-like.ts
@@ -65,7 +65,7 @@ export const useAuctionLike = ({ auctionId, initIsLiked, initLikeCount }: UseAuc
     onError: (_err, _vars, ctx) => {
       if (ctx?.prev) setState(ctx.prev);
       restoreAuctionsCache(queryClient, ctx?.snapshot);
-      showToast.error("찜 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+      showToast.error("관심 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
     },
 
     onSuccess: (data) => {
@@ -80,7 +80,7 @@ export const useAuctionLike = ({ auctionId, initIsLiked, initLikeCount }: UseAuc
 
   const toggleLike = () => {
     if (!user) {
-      showToast.error("찜을 누르려면 로그인이 필요합니다.");
+      showToast.error("관심 목록에 추가하려면 로그인이 필요합니다.");
       return;
     }
     likeMutation.mutate();

--- a/src/widgets/header/ui/header-actions.tsx
+++ b/src/widgets/header/ui/header-actions.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 
-import { Bell, Plus, User } from "lucide-react";
+import { Bell, Plus } from "lucide-react";
 
 import { getUserProfileServer } from "@/entities/user/api/user-api.server";
 import { ROUTES } from "@/shared/config/routes";
-import { Avatar, AvatarFallback, AvatarImage, Button } from "@/shared/ui";
+import { Button } from "@/shared/ui";
+import HeaderUserMenu from "@/widgets/header/ui/header-user-menu";
 
 export default async function HeaderActions({ userId }: { userId: number }) {
   const profile = await getUserProfileServer(userId);
@@ -32,14 +33,7 @@ export default async function HeaderActions({ userId }: { userId: number }) {
         <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-500" />
       </Button>
 
-      <Link href={ROUTES.myPage}>
-        <Avatar className="size-9">
-          <AvatarImage src={avatarUrl ?? undefined} alt={avatarAlt} />
-          <AvatarFallback>
-            <User className="size-5" />
-          </AvatarFallback>
-        </Avatar>
-      </Link>
+      <HeaderUserMenu avatarUrl={avatarUrl ?? undefined} avatarAlt={avatarAlt} />
     </div>
   );
 }

--- a/src/widgets/header/ui/header-user-menu.tsx
+++ b/src/widgets/header/ui/header-user-menu.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { LogOut, Moon, Sun, User } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { ROUTES } from "@/shared/config/routes";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/shared/ui";
+
+interface HeaderUserMenuProps {
+  avatarUrl?: string;
+  avatarAlt: string;
+}
+
+export default function HeaderUserMenu({ avatarUrl, avatarAlt }: HeaderUserMenuProps) {
+  const router = useRouter();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDarkMode = resolvedTheme === "dark";
+  const themeLabel = isDarkMode ? "라이트모드" : "다크모드";
+  const ThemeIcon = isDarkMode ? Sun : Moon;
+
+  const handleLogout = async () => {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } finally {
+      router.push(ROUTES.login);
+      router.refresh();
+    }
+  };
+
+  const handleToggleTheme = () => {
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="사용자 메뉴"
+          className="rounded-full focus-visible:outline-hidden"
+        >
+          <Avatar className="size-9">
+            <AvatarImage src={avatarUrl} alt={avatarAlt} />
+            <AvatarFallback>
+              <User className="size-5" />
+            </AvatarFallback>
+          </Avatar>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="mt-1.5">
+        <DropdownMenuItem asChild className="h-10 pl-3">
+          <Link href={ROUTES.myPage}>
+            <User className="size-4" />
+            마이페이지
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="h-10 pl-3" onSelect={handleToggleTheme}>
+          <ThemeIcon className="size-4" />
+          {themeLabel}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="h-10 pl-3" variant="destructive" onSelect={handleLogout}>
+          <LogOut className="size-4" />
+          로그아웃
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/widgets/header/ui/header-user-menu.tsx
+++ b/src/widgets/header/ui/header-user-menu.tsx
@@ -7,6 +7,7 @@ import { LogOut, Moon, Sun, User } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { ROUTES } from "@/shared/config/routes";
+import { showToast } from "@/shared/lib/utils/toast/show-toast";
 import {
   Avatar,
   AvatarFallback,
@@ -27,15 +28,20 @@ export default function HeaderUserMenu({ avatarUrl, avatarAlt }: HeaderUserMenuP
   const router = useRouter();
   const { resolvedTheme, setTheme } = useTheme();
   const isDarkMode = resolvedTheme === "dark";
-  const themeLabel = isDarkMode ? "라이트모드" : "다크모드";
+  const themeLabel = isDarkMode ? "라이트 모드" : "다크 모드";
   const ThemeIcon = isDarkMode ? Sun : Moon;
 
   const handleLogout = async () => {
     try {
-      await fetch("/api/auth/logout", { method: "POST" });
+      const response = await fetch("/api/auth/logout", { method: "POST" });
+      if (!response.ok) {
+        showToast.error("로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      }
+    } catch {
+      showToast.error("로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.");
     } finally {
-      router.push(ROUTES.login);
       router.refresh();
+      router.push(ROUTES.login);
     }
   };
 
@@ -63,7 +69,7 @@ export default function HeaderUserMenu({ avatarUrl, avatarAlt }: HeaderUserMenuP
         <DropdownMenuItem asChild className="h-10 pl-3">
           <Link href={ROUTES.myPage}>
             <User className="size-4" />
-            마이페이지
+            마이 페이지
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem className="h-10 pl-3" onSelect={handleToggleTheme}>


### PR DESCRIPTION
## 📖 개요

로그아웃 API 추가 및 헤더 사용자 메뉴 드롭다운 구현

## 📌 관련 이슈

- Close #356 

## 🛠️ 상세 작업 내용

- 인증 cookie를 제거하는 logout API 라우트 추가
- HeaderActions를 HeaderUserMenu 기반 구조로 리팩토링
- 프로필 이동, 테마 토글, 로그아웃을 포함한 드롭다운 메뉴 제공
- 경매 관심 실패 시 에러 메시지 문구 개선

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트
