### PR TITLE
fix(logout): clearAuthCookies 함수가 쿠키를 지우지 못하는 문제 수정

### DIFF
--- a/src/shared/lib/utils/auth/cookie-options.ts
+++ b/src/shared/lib/utils/auth/cookie-options.ts
@@ -64,7 +64,19 @@ export function setAuthCookies(
 }
 
 export function clearAuthCookies(response: NextResponse) {
-  response.cookies.delete(COOKIE_OPTIONS.ACCESS_TOKEN.name);
-  response.cookies.delete(COOKIE_OPTIONS.REFRESH_TOKEN.name);
-  response.cookies.delete(COOKIE_OPTIONS.USER_ID.name);
+  response.cookies.delete({
+    name: COOKIE_OPTIONS.ACCESS_TOKEN.name,
+    path: COOKIE_OPTIONS.ACCESS_TOKEN.options.path,
+    domain: COOKIE_OPTIONS.ACCESS_TOKEN.options.domain,
+  });
+  response.cookies.delete({
+    name: COOKIE_OPTIONS.REFRESH_TOKEN.name,
+    path: COOKIE_OPTIONS.REFRESH_TOKEN.options.path,
+    domain: COOKIE_OPTIONS.REFRESH_TOKEN.options.domain,
+  });
+  response.cookies.delete({
+    name: COOKIE_OPTIONS.USER_ID.name,
+    path: COOKIE_OPTIONS.USER_ID.options.path,
+    domain: COOKIE_OPTIONS.USER_ID.options.domain,
+  });
 }


### PR DESCRIPTION
## 📖 개요

clearAuthCookies 함수가 쿠키를 지우지 못하는 문제 수정

## 📌 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- name, path, domain 키 지정해서 수정

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트