### PR TITLE
[#392] fix(users): card 전체 클릭 시 상세 이동, 알림 설정 모달 캐싱 문제 수정

### DIFF
--- a/src/entities/auction/ui/user-item-card/ui/user-item-card.tsx
+++ b/src/entities/auction/ui/user-item-card/ui/user-item-card.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from "react";
 
 import Image from "next/image";
@@ -44,50 +45,21 @@ export function UserItemCard({
   footerNode,
   onClick,
 }: UserItemCardProps) {
-  const isInteractive = !!onClick;
+  const isInteractive = !!onClick || !!imageHref;
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-    if (e.key !== "Enter" && e.key !== " ") return;
-    e.preventDefault();
-    onClick?.();
-  };
-
-  const interactiveProps = isInteractive
-    ? {
-        role: "button" as const,
-        tabIndex: 0,
-        onKeyDown: handleKeyDown,
-        onClick,
-      }
-    : {};
-
-  const priceClassName = cn(
-    "font-bold tracking-tight",
-    isPriceGray ? "text-muted-foreground" : "text-brand-text"
-  );
-
-  const renderImage = () => {
-    const content = imageUrl ? (
-      <Image src={imageUrl} alt={name} fill className="object-cover" />
-    ) : (
-      <NoImage />
-    );
-
-    if (!imageHref) return content;
-
-    return (
-      <Link
-        href={imageHref}
-        className="block h-full w-full"
-        onClick={(e) => e.stopPropagation()}
-        aria-label={`${name} 상세로 이동`}
-      >
-        {content}
-      </Link>
-    );
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (onClick && (e.key === "Enter" || e.key === " ")) {
+      e.preventDefault();
+      onClick();
+    }
   };
 
   const renderPrice = () => {
+    const priceClassName = cn(
+      "font-bold tracking-tight",
+      isPriceGray ? "text-muted-foreground" : "text-brand-text"
+    );
+
     if (price != null && discountRate != null && discountRate > 0) {
       return (
         <div className="flex flex-col gap-0.5">
@@ -110,40 +82,55 @@ export function UserItemCard({
   };
 
   return (
-    <article
-      {...interactiveProps}
+    <div
       className={cn(
-        "bg-card border-border flex w-full flex-col gap-3 rounded-lg border p-4 transition-colors",
-        isInteractive &&
-          "hover:bg-secondary/20 cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        "bg-card border-border relative flex w-full flex-col gap-3 rounded-lg border p-4 transition-colors",
+        isInteractive && "hover:bg-secondary/20 cursor-pointer"
       )}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
     >
-      <div className="flex w-full items-start gap-3">
-        <div className="bg-secondary relative size-28 shrink-0 overflow-hidden rounded-lg">
-          {renderImage()}
-          {overlayNode}
-        </div>
+      {imageHref && (
+        <Link
+          href={imageHref}
+          className="absolute inset-0 z-0"
+          aria-label={`${name} 상세로 이동`}
+        />
+      )}
 
-        <div className="flex h-28 flex-1 flex-col justify-between py-0.5">
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              {badgeNode}
-              {actionNode}
-            </div>
-
-            <div className="flex flex-col px-1">
-              <h3 className="text-foreground line-clamp-1 text-base leading-4 tracking-tight">
-                {name}
-              </h3>
-              <div className="mt-1.5">{renderPrice()}</div>
-            </div>
+      <div className="pointer-events-none relative z-10 flex w-full flex-col gap-3">
+        <div className="flex w-full items-start gap-3">
+          <div className="bg-secondary relative size-28 shrink-0 overflow-hidden rounded-lg">
+            {imageUrl ? (
+              <Image src={imageUrl} alt={name} fill className="object-cover" />
+            ) : (
+              <NoImage />
+            )}
+            {overlayNode && <div className="pointer-events-auto">{overlayNode}</div>}
           </div>
 
-          <p className="text-muted-foreground px-1 text-xs leading-4">{date}</p>
-        </div>
-      </div>
+          <div className="flex h-28 flex-1 flex-col justify-between py-0.5">
+            <div className="flex flex-col gap-2">
+              <div className="pointer-events-auto flex items-center justify-between">
+                {badgeNode}
+                {actionNode}
+              </div>
 
-      {footerNode}
-    </article>
+              <div className="flex flex-col px-1">
+                <h3 className="text-foreground line-clamp-1 text-base leading-4 tracking-tight">
+                  {name}
+                </h3>
+                <div className="mt-1.5">{renderPrice()}</div>
+              </div>
+            </div>
+            <p className="text-muted-foreground px-1 text-xs leading-4">{date}</p>
+          </div>
+        </div>
+
+        {footerNode && <div className="pointer-events-auto">{footerNode}</div>}
+      </div>
+    </div>
   );
 }

--- a/src/features/notification-preference/index.ts
+++ b/src/features/notification-preference/index.ts
@@ -2,6 +2,7 @@ export { NotificationPreferenceItemCard } from "./ui/notification-preference-ite
 export { NotificationPreferenceSettingsModal } from "./ui/notification-preference-settings-modal";
 export type { NotificationPreferenceItemType } from "./model/types";
 export {
+  notificationKeys,
   useNotificationList,
   useNotificationSettings,
   useUpdateNotificationSettings,


### PR DESCRIPTION
<!-- PR 제목 규칙 [#이슈번호] type(scope): 한 줄 요약 -->

## 📖 개요

<!-- 이 PR의 작업 내용을 간략히 작성해주세요 -->
- users page의 item card에서 이미지 뿐만 아니라 전체를 클릭해도 상세로 이동하도록 수정
- 알림 설정 모달을 불러올 때 데이터를 가져온 뒤 보여주도록 해서 깜빡거리는 문제 해결

## 📌 관련 이슈

<!-- 연결할 이슈를 작성해주세요 -->

- Close #392

## 🛠️ 상세 작업 내용

<!-- 작업한 내용을 상세히 작성해주세요 -->

- Task

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트

## 📸 스크린샷 (Optional)

<!-- UI/UX 변경 사항이 있을 경우 이미지를 첨부해주세요 -->

_N/A_

## ⚠️ 주의 사항 (Optional)

<!-- 다른 기능이나 UI 등 영향을 줄 수 있는 변경이라면 설명해주세요 -->

_N/A_

## 👥 리뷰 확인 사항 (Optional)

<!-- 리뷰어가 집중해서 봐야 하는 부분이 있다면 작성해주세요 -->

_N/A_
