### PR TITLE
fix(notification): 알림 연결 불안정 토스트에서 console.warn으로 변경

### DIFF
--- a/src/features/notification/ui/notification-sse-provider.tsx
+++ b/src/features/notification/ui/notification-sse-provider.tsx
@@ -165,7 +165,7 @@ export function NotificationSseProvider() {
           sourceRef.current = null;
         }
         if (!hasNotifiedErrorRef.current) {
-          showToast.warning("실시간 알림 연결이 불안정합니다.");
+          console.warn("실시간 알림 연결이 불안정합니다.");
           hasNotifiedErrorRef.current = true;
         }
         scheduleReconnect();


### PR DESCRIPTION
## 📖 개요

알림 연결 불안정 토스트에서 console.warn으로 변경

## 📌 관련 이슈

_N/A_

## 🛠️ 상세 작업 내용

- 알림 연결 불안정 토스트에서 console.warn으로 변경

## ✅ PR 체크리스트

- [x] 기능 테스트
- [x] UI/레이아웃 확인
- [x] 타입 정의 및 로직 셀프 리뷰
- [x] 불필요한 주석 및 코드 제거
- [x] `pnpm build` 로 실행 테스트
- [x] 다른 기능에 영향 없는지 테스트
